### PR TITLE
fix(whoop): correct historical HRV/RHR, workout count, and perf-assessment sentinel in composite tools

### DIFF
--- a/src/projections/performance_assessment.ts
+++ b/src/projections/performance_assessment.ts
@@ -1,6 +1,15 @@
 import type { PerformanceAssessmentOutT } from "../schemas/performance.js";
 import { isObject, asNumber, asString, asBool } from "../lib/walk.js";
 
+// Whoop returns 1000 as a sentinel for the recovery counters when the count is
+// effectively unbounded / not applicable (you cannot log 1000 recoveries in a
+// week or month). Surface it as null instead of a misleading literal.
+const RECOVERY_COUNT_SENTINEL = 1000;
+function recoveryCount(v: unknown): number | null {
+  const n = asNumber(v);
+  return n === null || n >= RECOVERY_COUNT_SENTINEL ? null : n;
+}
+
 export function projectPerformanceAssessment(
   raw: unknown,
   period: "WEEK" | "MONTH",
@@ -10,9 +19,9 @@ export function projectPerformanceAssessment(
     period,
     is_assessment_needed: asBool(root.is_assessment_needed) ?? false,
     has_assessment: asBool(root.has_assessment) ?? false,
-    total_recoveries: asNumber(root.total_recoveries),
+    total_recoveries: recoveryCount(root.total_recoveries),
     required_recoveries: asNumber(root.required_recoveries),
-    recoveries_before_recent_cutoff: asNumber(root.recoveries_before_recent_cutoff),
+    recoveries_before_recent_cutoff: recoveryCount(root.recoveries_before_recent_cutoff),
     expected_assessment_during: asString(root.expected_assessment_during),
     next_assessment_during: asString(root.next_assessment_during),
   };

--- a/src/projections/today.ts
+++ b/src/projections/today.ts
@@ -1,6 +1,6 @@
 import type { TodayOutT } from "../schemas/today.js";
 import { findByType, isObject, asArray, asNumber, asString } from "../lib/walk.js";
-import { stateFromStyle } from "./recovery.js";
+import { projectRecovery, stateFromStyle } from "./recovery.js";
 
 // Whoop's home payload's authoritative score source is SCORE_GAUGE_STICKY which
 // contains a gauges[] array with one entry per pillar (SLEEP, RECOVERY, STRAIN).
@@ -74,18 +74,11 @@ function sleepSummary(resp: unknown, date: string): SleepSummary | null {
   };
 }
 
-// HRV + RHR from the lightweight /developer/v2/recovery endpoint (the /home gauge
-// only carries the recovery *score*, not the underlying HRV/RHR). Picks the
-// recovery whose created date matches `date`, else the most recent.
-function recoverySummary(resp: unknown, date: string): { hrv_ms: number | null; rhr_bpm: number | null } {
-  const records = asArray(isObject(resp) ? resp.records : null).filter(
-    (r): r is Record<string, unknown> => isObject(r),
-  );
-  const pick = records.find((r) => asString(r.created_at)?.slice(0, 10) === date) ?? records[0];
-  const score = pick && isObject(pick.score) ? (pick.score as Record<string, unknown>) : {};
-  const hrv = asNumber(score.hrv_rmssd_milli);
-  return { hrv_ms: hrv === null ? null : Math.round(hrv), rhr_bpm: asNumber(score.resting_heart_rate) };
-}
+// HRV + RHR come from the date-aligned deep-dive recovery payload via
+// projectRecovery (the same source whoop_recovery uses). The previous approach
+// matched /developer/v2/recovery records by created_at.slice(0,10), which is
+// off-by-one because created_at is UTC: on a historical lookup it returned the
+// adjacent day HRV/RHR.
 
 export function projectToday(input: ProjectTodayInput): TodayOutT {
   const { home, sleep, recovery, state, date } = input;
@@ -99,8 +92,11 @@ export function projectToday(input: ProjectTodayInput): TodayOutT {
 
   const recoveryStyle = recoveryGauge ? asString(recoveryGauge.progress_fill_style) : null;
 
-  // Count workouts: ACTIVITY tiles in home (excludes the navigation tiles by checking for content)
-  let workoutsCount = 0;
+  // Count workouts: ACTIVITY tiles in home with real content. Whoop lists the
+  // nightly SLEEP as an ACTIVITY tile too (content.type === "SLEEP"); exclude it
+  // so the count reflects true exercises only. Dedupe by activity id in case a
+  // tile is referenced from more than one section.
+  const workoutIds = new Set<string>();
   function countWorkouts(n: unknown): void {
     if (Array.isArray(n)) {
       for (const x of n) countWorkouts(x);
@@ -109,15 +105,21 @@ export function projectToday(input: ProjectTodayInput): TodayOutT {
     if (!isObject(n)) return;
     if (n.type === "ACTIVITY") {
       const c = isObject(n.content) ? (n.content as Record<string, unknown>) : null;
-      if (c && asString(c.title)) workoutsCount++;
+      const title = c ? asString(c.title) : null;
+      const innerType = c ? asString(c.type) : null;
+      if (c && title && innerType?.toUpperCase() !== "SLEEP") {
+        const id = asString(c.activity_v2_id) ?? `${title}|${asString(c.start_time_text) ?? ""}`;
+        workoutIds.add(id);
+      }
     }
     for (const v of Object.values(n)) countWorkouts(v);
   }
   countWorkouts(home);
+  const workoutsCount = workoutIds.size;
 
   // Sleep summary from the lightweight /developer/v2/activity/sleep endpoint
   const sleepSum = sleep ? sleepSummary(sleep, date) : null;
-  const recSum = recovery ? recoverySummary(recovery, date) : null;
+  const recProj = recovery ? projectRecovery(recovery, date) : null;
 
   // Activity state
   const stateObj = isObject(state) ? state : {};
@@ -133,8 +135,8 @@ export function projectToday(input: ProjectTodayInput): TodayOutT {
     recovery: {
       score: gaugeScore(recoveryGauge),
       state: stateFromStyle(recoveryStyle),
-      hrv_ms: recSum?.hrv_ms ?? null,
-      rhr_bpm: recSum?.rhr_bpm ?? null,
+      hrv_ms: recProj?.hrv.ms ?? null,
+      rhr_bpm: recProj?.rhr.bpm ?? null,
     },
     sleep: {
       performance_pct: gaugeScore(sleepGauge) ?? sleepSum?.performance_pct ?? null,

--- a/src/tools/v2/day.ts
+++ b/src/tools/v2/day.ts
@@ -22,7 +22,9 @@ export function registerDay(server: McpServer, client: WhoopClient): void {
         client.get("/home-service/v1/home", { date }),
         // Light sleep summary (~1 KB) — the full hypnogram lives in whoop_sleep.
         client.get("/developer/v2/activity/sleep", { start, end, limit: "10" }).catch(() => null),
-        client.get("/developer/v2/recovery", { start, end, limit: "10" }).catch(() => null),
+        // Deep-dive recovery is date-aligned; the /developer/v2/recovery records
+        // match by UTC created_at, which is off-by-one on historical lookups.
+        client.get("/home-service/v1/deep-dive/recovery", { date }).catch(() => null),
       ]);
       const projected = projectToday({ home, sleep, recovery, state: null, date });
       try {

--- a/src/tools/v2/today.ts
+++ b/src/tools/v2/today.ts
@@ -18,8 +18,10 @@ export function registerToday(server: McpServer, client: WhoopClient): void {
         client.get("/home-service/v1/home", { date }),
         // Light sleep summary (~1 KB) — the full hypnogram lives in whoop_sleep.
         client.get("/developer/v2/activity/sleep", { limit: "5" }).catch(() => null),
-        // HRV / RHR (the /home gauge only carries the recovery score).
-        client.get("/developer/v2/recovery", { limit: "5" }).catch(() => null),
+        // HRV / RHR from the date-aligned deep-dive recovery tile. (The /home gauge
+        // only carries the score; matching /developer/v2/recovery by created_at is
+        // off-by-one for non-UTC users because created_at is UTC.)
+        client.get("/home-service/v1/deep-dive/recovery", { date }).catch(() => null),
         client.get("/activities-service/v1/user-state").catch(() => null),
       ]);
       const projected = projectToday({ home, sleep, recovery, state, date });

--- a/tests/projections/round1.test.ts
+++ b/tests/projections/round1.test.ts
@@ -148,7 +148,7 @@ describe("projectSleep (captured)", () => {
 describe("projectToday for whoop_day (state=null, past date)", () => {
   const home = load("home.json");
   const sleep = load("activity_sleep.json");
-  const out = projectToday({ home, sleep, recovery: load("activity_recovery.json"), state: null, date: "2026-05-22" });
+  const out = projectToday({ home, sleep, recovery: load("deep_dive_recovery.json"), state: null, date: "2026-05-22" });
 
   it("parses schema with state=null", () => {
     expect(() => TodayOut.parse(out)).not.toThrow();
@@ -171,7 +171,7 @@ describe("projectToday for whoop_day (state=null, past date)", () => {
 describe("projectToday (captured)", () => {
   const home = load("home.json");
   const sleep = load("activity_sleep.json");
-  const out = projectToday({ home, sleep, recovery: load("activity_recovery.json"), state: null, date: "2026-05-23" });
+  const out = projectToday({ home, sleep, recovery: load("deep_dive_recovery.json"), state: null, date: "2026-05-23" });
 
   it("parses schema", () => {
     expect(() => TodayOut.parse(out)).not.toThrow();
@@ -186,8 +186,10 @@ describe("projectToday (captured)", () => {
   it("extracts strain score (17.8)", () => {
     expect(out.strain.score).toBe(17.8);
   });
-  it("counts ACTIVITY tiles for workouts_count > 0", () => {
-    expect(out.strain.workouts_count).toBeGreaterThanOrEqual(0);
+  it("counts ACTIVITY tiles, excluding the SLEEP tile", () => {
+    // home.json has two titled ACTIVITY tiles: "SLEEP" and "STRENGTH TRAINER".
+    // Only the workout counts toward the total.
+    expect(out.strain.workouts_count).toBe(1);
   });
   it("populates sleep stages from the companion sleep summary", () => {
     expect(out.sleep.stages.rem_ms).toBeGreaterThan(0);
@@ -195,9 +197,9 @@ describe("projectToday (captured)", () => {
     expect(out.sleep.stages.sws_ms).toBeGreaterThan(0);
     expect(out.sleep.total_sleep_ms).toBeGreaterThan(0);
   });
-  it("populates recovery HRV + RHR from /developer/v2/recovery", () => {
-    expect(out.recovery.hrv_ms).toBeGreaterThan(0);
-    expect(out.recovery.rhr_bpm).toBeGreaterThan(0);
+  it("populates recovery HRV + RHR from the date-aligned deep-dive recovery tile", () => {
+    expect(out.recovery.hrv_ms).toBe(42);
+    expect(out.recovery.rhr_bpm).toBe(68);
   });
 });
 

--- a/tests/projections/round3_data_fixes.test.ts
+++ b/tests/projections/round3_data_fixes.test.ts
@@ -13,6 +13,7 @@ import { projectBehaviorImpact } from "../../src/projections/behavior_impact.js"
 import { projectWorkout } from "../../src/projections/workout.js";
 import { projectLiftProgression } from "../../src/projections/lift_progression.js";
 import { projectRecovery } from "../../src/projections/recovery.js";
+import { projectPerformanceAssessment } from "../../src/projections/performance_assessment.js";
 
 import { TrendOut } from "../../src/schemas/trend.js";
 import { CycleOut } from "../../src/schemas/womens_health.js";
@@ -22,6 +23,7 @@ import { BehaviorImpactOut } from "../../src/schemas/journal.js";
 import { WorkoutOut } from "../../src/schemas/workouts.js";
 import { LiftProgressionOut } from "../../src/schemas/strength.js";
 import { RecoveryOut } from "../../src/schemas/recovery.js";
+import { PerformanceAssessmentOut } from "../../src/schemas/performance.js";
 
 const load = (name: string): unknown => JSON.parse(readFileSync(resolve("tests/fixtures", name), "utf8"));
 
@@ -175,5 +177,30 @@ describe("projectRecovery — SpO2 + skin temp from /developer/v2/recovery", () 
   });
   it("surfaces skin temperature from the v2 record (was null pre-fix)", () => {
     expect(out.skin_temp_c).toBe(33.7);
+  });
+});
+
+
+describe("projectPerformanceAssessment - 1000 sentinel for recovery counts -> null", () => {
+  const raw = {
+    is_assessment_needed: true,
+    has_assessment: false,
+    total_recoveries: 1000,
+    required_recoveries: 14,
+    recoveries_before_recent_cutoff: 1000,
+    expected_assessment_during: "['2026-05-01','2026-06-01')",
+    next_assessment_during: "['2026-06-01','2026-07-01')",
+  };
+  const out = projectPerformanceAssessment(raw, "MONTH");
+
+  it("parses schema", () => {
+    expect(() => PerformanceAssessmentOut.parse(out)).not.toThrow();
+  });
+  it("nulls the 1000 sentinel rather than reporting a fake count", () => {
+    expect(out.total_recoveries).toBeNull();
+    expect(out.recoveries_before_recent_cutoff).toBeNull();
+  });
+  it("keeps real counts intact", () => {
+    expect(out.required_recoveries).toBe(14);
   });
 });


### PR DESCRIPTION
## Summary

Three bugs in the composite tools (`whoop_today`, `whoop_day`, `whoop_performance_assessment`), found while auditing live-API output against the tool descriptions. Each is small and self-contained; tests are added/updated and the full suite passes.

## 1. Historical HRV/RHR were off by one day (`whoop_today`, `whoop_day`)

`projectToday` selected the HRV/RHR record from `/developer/v2/recovery` by matching `created_at.slice(0, 10)` against the requested **local** date. `created_at` is a **UTC** timestamp, so for any user in a non-UTC timezone a historical lookup can match the *adjacent* day's recovery.

Example (UTC+10): `whoop_day` for a past date returned the **next** day's HRV/RHR, while the recovery *score* (sourced from `/home`) was correct for the requested day — an internally inconsistent snapshot. `whoop_today` avoided it only by luck, because its `records[0]` "most recent" fallback usually lands on the right record.

**Fix:** read HRV/RHR from the date-aligned deep-dive recovery endpoint via `projectRecovery` — the same source the standalone `whoop_recovery` tool already uses — so the composite and the standalone tool agree.

## 2. `workouts_count` counted the night's sleep (`whoop_today`, `whoop_day`)

Whoop's `/home` payload lists the night's sleep as an `ACTIVITY` tile (`content.type === "SLEEP"`), so the composite count was always one higher than the real workout count. (`whoop_strain`, which reads a different endpoint, was already correct.)

**Fix:** skip `ACTIVITY` tiles whose `content.type === "SLEEP"`, and dedupe by `activity_v2_id`.

## 3. `performance_assessment` surfaced a `1000` sentinel

`/coaching-service/v1/performance-assessment/...` returns `1000` for `total_recoveries` and `recoveries_before_recent_cutoff` as an unbounded / not-applicable placeholder, and it was passed through verbatim.

**Fix:** map values `>= 1000` to `null`.

## Tests

- Updated the `projectToday` tests to use the deep-dive recovery fixture and to assert the sleep tile is excluded from `workouts_count` (now `1` for `home.json`).
- Added `projectPerformanceAssessment` coverage for the sentinel.
- `npx tsc --noEmit` clean; all 236 tests pass.

## Notes

- The historical *sleep block* selection in `whoop_day` (which night maps to a given date) is a separate, lower-confidence question and is intentionally left unchanged here.