### PR TITLE
feat: add whoop_sleep_edit for editing sleep start/end times

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/banner.svg" alt="totem — 48 tools, 47 microservices, 311 endpoints" width="820">
+  <img src="assets/banner.svg" alt="totem — 49 tools, 47 microservices, 311 endpoints" width="820">
 </p>
 
 <p align="center">
@@ -30,7 +30,7 @@
   <sub>▶ 2-min demo — the full <code>totem cloud</code> flow: install → Whoop login → Fly deploy → Claude connector → first query.</sub>
 </p>
 
-48 tools, structured zod-validated outputs, bundled catalogs (372 exercises, 308 behaviors, 203 sports, 311 endpoints), write-safety harness, automatic Cognito token refresh, session-scoped catalog gate. TypeScript 6, Node 24, 233 tests.
+49 tools, structured zod-validated outputs, bundled catalogs (372 exercises, 308 behaviors, 203 sports, 311 endpoints), write-safety harness, automatic Cognito token refresh, session-scoped catalog gate. TypeScript 6, Node 24, 235 tests.
 
 > **Totem is becoming a universal wearables bridge.** Whoop is the first adapter — every metric, fully wired. Fitbit, Apple Watch, and Garmin are in progress ([contributors welcome](CONTRIBUTING.md)). The MCP + projection layer is device-agnostic; an adapter just maps its source into the same shared schemas, so everything below applies to whatever you wear.
 
@@ -44,7 +44,7 @@
 2. [Why this exists](#why-this-exists)
 3. [What it does](#what-it-does)
 4. [Architecture](#architecture)
-5. [The 48 tools](#the-48-tools)
+5. [The 49 tools](#the-49-tools)
 6. [Authentication](#authentication)
 7. [Write-safety harness](#write-safety-harness)
 8. [Bundled catalogs](#bundled-catalogs)
@@ -138,7 +138,7 @@ This MCP wraps the iOS surface.
 | Compare-windows, sleep coach, calendar grid, performance assessment | `whoop_compare`, `whoop_sleep_need`, `whoop_calendar`, `whoop_performance_assessment` |
 | Live HR / activity state / live stress | `whoop_live_*` (3 tools) |
 | Community leaderboards, hidden metrics, women's health (cycle / symptoms / MCI) | `whoop_leaderboard`, `whoop_hidden_metric`, `whoop_cycle*` |
-| **14 write tools** — log workouts, journal entries, profile edits, smart-alarm config | various |
+| **15 write tools** — log workouts, journal entries, profile edits, smart-alarm config, edit sleep times | various |
 
 If recovery + sleep totals + workout list is enough for you, use the public OAuth API. If anything in the table is interesting, you need this. The iOS API was discovered via mitmproxy — full methodology in [`WHOOP.md`](WHOOP.md).
 
@@ -146,7 +146,7 @@ If recovery + sleep totals + workout list is enough for you, use the public OAut
 
 ## What it does
 
-The MCP runs as a local Node process. It speaks **Model Context Protocol** over stdio (or HTTP for remote deployments), registers 48 tools at startup, and waits for tool calls from a connected MCP client.
+The MCP runs as a local Node process. It speaks **Model Context Protocol** over stdio (or HTTP for remote deployments), registers 49 tools at startup, and waits for tool calls from a connected MCP client.
 
 When a tool is called:
 
@@ -158,14 +158,14 @@ When a tool is called:
 
 Writes follow the same path plus a **preview gate**: every write tool defaults `confirm: false`, returning a preview of what would be sent. Claude must explicitly re-call with `confirm: true` to fire.
 
-See [The 48 tools](#the-48-tools) for the full per-tool reference.
+See [The 49 tools](#the-49-tools) for the full per-tool reference.
 
 ---
 
 ## Architecture
 
 ```
-Claude Desktop / Code  ──stdio──▶  src/server.ts  ──▶  48 tool handlers
+Claude Desktop / Code  ──stdio──▶  src/server.ts  ──▶  49 tool handlers
                                                           │
                                        ┌──────────────────┼──────────────────┐
                                        ▼                  ▼                  ▼
@@ -194,7 +194,7 @@ When Whoop changes a response shape, the projection emits unexpected data, zod's
 
 ---
 
-## The 48 tools
+## The 49 tools
 
 Compact summary. **Full per-tool reference (input shape · source endpoints · output shape · notes) → [`TOOLS.md`](TOOLS.md).** Tools marked ⚠️ are writes (default `confirm: false`, preview-first). Tools marked 🔒 are gated — the catalog tool in the same group must be called once per session before they'll run.
 
@@ -216,7 +216,7 @@ Compact summary. **Full per-tool reference (input shape · source endpoints · o
 | **Settings** (4) | `whoop_hr_zones` · `whoop_hr_zones_set` ⚠️ · `whoop_profile_update` ⚠️ · `whoop_hidden_metric` ⚠️ |
 | **Escape hatch** (2) | `whoop_raw` · `whoop_endpoints` |
 
-**Total: 48** (32 reads + 14 writes + 2 escape hatches). For each tool's input args, source endpoint(s), and output shape, see [`TOOLS.md`](TOOLS.md).
+**Total: 49** (32 reads + 15 writes + 2 escape hatches). For each tool's input args, source endpoint(s), and output shape, see [`TOOLS.md`](TOOLS.md).
 
 ---
 
@@ -315,7 +315,7 @@ The MCP loads `.env` from the repo root (relative to `server.js`). Use absolute 
 
 ## Remote hosting
 
-The MCP also speaks HTTP — deploy once, use from multiple devices. Same 48 tools, same auto-refresh, behind a bearer-token gate at a URL.
+The MCP also speaks HTTP — deploy once, use from multiple devices. Same 49 tools, same auto-refresh, behind a bearer-token gate at a URL.
 
 ```bash
 # 1. Local bootstrap (Cognito needs an interactive MFA prompt)
@@ -517,7 +517,7 @@ Versions are sourced from the places that already host them — git tags + GitHu
 
 | Approach | Pros | Cons |
 |---|---|---|
-| **This MCP** | Full iOS API surface (48 total: 32 reads + 14 writes + 2 escape hatches), writes supported, structured outputs, auto-refresh, write-safety, session-scoped catalog gate | Unsupported by Whoop (see [FAQ](#faq) for what that means); reverse-engineered (Whoop could break it at any time); local install required |
+| **This MCP** | Full iOS API surface (49 total: 32 reads + 15 writes + 2 escape hatches), writes supported, structured outputs, auto-refresh, write-safety, session-scoped catalog gate | Unsupported by Whoop (see [FAQ](#faq) for what that means); reverse-engineered (Whoop could break it at any time); local install required |
 | Whoop's public OAuth API | Official, supported, 6 webhook events, scoped permissions | Only 13 endpoints; read-only; no journal/strength/stress/coach/smart-alarm/trends/hypnogram; numeric `sport_id` removed 2025-09-01; 429s exist |
 | HealthKit-based scraper | Bypass Whoop entirely; uses Apple's data sync | Loses Whoop-specific data (recovery score, journal, coach); requires iOS device involvement |
 | Direct mitmproxy capture | See everything | Manual, not programmable, doesn't scale |

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,4 +1,4 @@
-# The 48 tools
+# The 49 tools
 
 > Full reference for every tool exposed by [totem](README.md). Each entry has the input shape, source endpoint(s), and output shape. Catalog tools (`whoop_sports_catalog`, `whoop_lift_catalog`, `whoop_journal_catalog`) unlock their gated counterparts — see [README → Bundled catalogs](README.md#bundled-catalogs).
 
@@ -35,7 +35,7 @@ Per-day recovery / sleep / strain scores for a month.
 - **Source endpoints (2 parallel):** `/home-service/v1/calendar/overview?date=`, `/home-service/v1/calendar/recovery?date=`
 - **Output:** `{month: "YYYY-MM", days: [{date, recovery_score, recovery_state, sleep_score, day_strain}]}`
 
-### Deep dives (3)
+### Deep dives (3 read + 1 write)
 
 #### `whoop_recovery`
 Recovery score + HRV (with baseline) + RHR (with baseline) + respiratory rate + SpO2 + skin temp + sleep performance.
@@ -57,6 +57,14 @@ Sleep duration, time in bed, efficiency, performance, consistency, all 4 stages 
 Note: the underlying endpoint is 848 KB. The projection extracts ~500 chars.
 
 **Partially populated** — `sleep_hrv_ms`, `respiratory_rate`, `debt_ms`, `latency_ms` aren't exposed by this endpoint and return `null`. Everything else **is** populated: the per-stage durations + percentages (REM/light/SWS/wake), the **`hypnogram`** (reconstructed from the per-stage HR-curve points — timed off their clock labels, anchored to the sleep window), and **`sleep_hr`** (avg/min).
+
+#### `whoop_sleep_edit` ⚠️ WRITE
+Change a sleep's start and/or end time. Resolves the sleep's `activity_id` from `date`; an omitted bound keeps the current value. Times are sent as UTC. Set `resolve_overlaps:true` if the new window overlaps an adjacent sleep/nap.
+
+- **Input:** `{date?: string, start?: string (ISO+offset), end?: string (ISO+offset), resolve_overlaps?: boolean, confirm?: boolean}` (at least one of `start`/`end` required)
+- **Source:** `GET /home-service/v1/deep-dive/sleep/last-night?date=` to resolve `activity_id` + current window, then `PUT /core-details-bff/v2/sleep-details/{activityId}` with body `{start_time, end_time, resolve_overlaps?}`
+- **Output (confirm=false):** `{preview: true, will_execute: {...}, set_confirm_true_to_run: true}`
+- **Output (confirm=true):** `{edited: true, activity_id, start, end}`
 
 #### `whoop_strain`
 Day strain + HR zone time buckets + steps + strength activity time + workouts count.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@thebriangao/totem",
   "version": "1.4.4",
   "mcpName": "io.github.thebriangao/totem",
-  "description": "Totem — talk to your wearables with AI over MCP. Today: full Whoop access via its private iOS API (48 tools, read + write, zod-validated outputs, auto-refresh Cognito auth). Fitbit, Apple Watch, and Garmin adapters in progress.",
+  "description": "Totem — talk to your wearables with AI over MCP. Today: full Whoop access via its private iOS API (49 tools, read + write, zod-validated outputs, auto-refresh Cognito auth). Fitbit, Apple Watch, and Garmin adapters in progress.",
   "license": "MIT",
   "author": "Brian Gao",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.thebriangao/totem",
-  "description": "Totem — talk to your wearables with AI. Today: full Whoop access (48 tools).",
+  "description": "Totem — talk to your wearables with AI. Today: full Whoop access (49 tools).",
   "repository": {
     "url": "https://github.com/thebriangao/totem",
     "source": "github"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -88,7 +88,7 @@ function printBanner(): void {
     "",
     w(ANSI.brandDim, "   ▁▁▁▁▂▂▆▂▁▁▁▁▁▁▁▁▂▂▆▂▁▁▁▁▁▁▁▁▂▂▆▂▁▁▁▁▁▁▁▁▂▂▆▂▁▁▁▁▁▁▁▁▂▂▆▂▁▁▁▁▁▁▁▁▂▂▆▂▁▁▁"),
     "",
-    `   ${w(ANSI.bold, "v" + VERSION)}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "48 tools")}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "47 microservices")}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "311 endpoints")}`,
+    `   ${w(ANSI.bold, "v" + VERSION)}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "49 tools")}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "47 microservices")}  ${w(ANSI.gray, "·")}  ${w(ANSI.white, "311 endpoints")}`,
     "",
   ];
   for (const line of lines) console.error(line);
@@ -312,7 +312,7 @@ const commands: Record<string, Cmd> = {
   },
   tools: {
     group: "Inspect",
-    desc: "List the MCP tools the server exposes (48 total)",
+    desc: "List the MCP tools the server exposes (49 total)",
     run: async () => {
       const reads = [
         "whoop_today", "whoop_day", "whoop_profile", "whoop_calendar", "whoop_recovery",
@@ -325,7 +325,7 @@ const commands: Record<string, Cmd> = {
         "whoop_smart_alarm", "whoop_leaderboard", "whoop_communities", "whoop_hr_zones",
       ];
       const writes = [
-        "whoop_activity_create", "whoop_activity_delete", "whoop_lift_log",
+        "whoop_activity_create", "whoop_activity_delete", "whoop_sleep_edit", "whoop_lift_log",
         "whoop_lift_template_save", "whoop_lift_custom_exercise", "whoop_journal_log",
         "whoop_journal_autopop", "whoop_cycle_log", "whoop_symptom_log",
         "whoop_smart_alarm_set", "whoop_hr_zones_set", "whoop_profile_update",

--- a/src/schemas/sleep.ts
+++ b/src/schemas/sleep.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { IsoDateTime } from "./primitives.js";
+import { IsoDateTime, withPreview } from "./primitives.js";
 
 export const SleepStageEnum = z.enum(["AWAKE", "LIGHT", "REM", "SWS"]);
 
@@ -38,3 +38,10 @@ export const SleepOut = z.object({
   respiratory_rate: z.number().nullable(),
 });
 export type SleepOutT = z.infer<typeof SleepOut>;
+
+export const SleepEditOut = withPreview(z.object({
+  edited: z.literal(true),
+  activity_id: z.string(),
+  start: IsoDateTime,
+  end: IsoDateTime,
+}));

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -9,6 +9,7 @@ import { registerCalendar } from "./v2/calendar.js";
 // Deep dives
 import { registerRecovery } from "./v2/recovery.js";
 import { registerSleep } from "./v2/sleep.js";
+import { registerSleepEdit } from "./v2/sleep_edit.js";
 import { registerStrain } from "./v2/strain.js";
 // Trends + compare
 import { registerTrend } from "./v2/trend.js";
@@ -99,9 +100,10 @@ export function registerTools(server: McpServer, client: WhoopClient): void {
   registerLeaderboard(server, client);
   registerCommunities(server, client);
   registerHrZones(server, client);
-  // Writes (14: 13 + coach_ask)
+  // Writes (15: 14 + coach_ask)
   registerActivityCreate(server, client);
   registerActivityDelete(server, client);
+  registerSleepEdit(server, client);
   registerLiftLog(server, client);
   registerLiftTemplateSave(server, client);
   registerLiftCustomExercise(server, client);

--- a/src/tools/v2/sleep_edit.ts
+++ b/src/tools/v2/sleep_edit.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { SleepEditOut } from "../../schemas/sleep.js";
+import { preview } from "../../whoop/write_safety.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { todayIso } from "../../lib/dates.js";
+import { isObject, asString } from "../../lib/walk.js";
+
+// The sleep's activity_id + current window live at
+// header_section.destination.parameters of the deep-dive (same source projectSleep reads).
+export function sleepActivity(raw: unknown): { activityId: string | null; start: string | null; end: string | null } {
+  const header = isObject(raw) ? raw.header_section : null;
+  const dest = isObject(header) ? header.destination : null;
+  const params = isObject(dest) && isObject(dest.parameters) ? dest.parameters : {};
+  return {
+    activityId: asString(params.activity_id),
+    start: asString(params.start_time),
+    end: asString(params.end_time),
+  };
+}
+
+export function registerSleepEdit(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_sleep_edit",
+    "WRITE: change a sleep's start and/or end time. Resolves the sleep's activity_id from `date` (default today); pass start and/or end (ISO-8601, any offset — sent as UTC), an omitted bound keeps the current value. Set resolve_overlaps:true if the new window overlaps an adjacent sleep/nap. Preview unless confirm:true.",
+    {
+      date: z.iso.date().optional(),
+      start: z.iso.datetime({ offset: true }).optional(),
+      end: z.iso.datetime({ offset: true }).optional(),
+      resolve_overlaps: z.boolean().optional(),
+      confirm: z.boolean().default(false),
+    },
+    async ({ date, start, end, resolve_overlaps, confirm }) => {
+      const d = date ?? todayIso();
+      if (!start && !end) {
+        return { content: [{ type: "text", text: jsonOut({ error: "Provide at least one of start/end (ISO-8601 datetime)." }) }], isError: true };
+      }
+
+      // Resolve the sleep + its current window so an omitted bound is preserved.
+      const sleep = sleepActivity(await client.get("/home-service/v1/deep-dive/sleep/last-night", { date: d }));
+      if (!sleep.activityId) {
+        return { content: [{ type: "text", text: jsonOut({ error: `No sleep found for ${d}.` }) }], isError: true };
+      }
+
+      const startSrc = start ?? sleep.start;
+      const endSrc = end ?? sleep.end;
+      const startMs = startSrc ? Date.parse(startSrc) : NaN;
+      const endMs = endSrc ? Date.parse(endSrc) : NaN;
+      if (Number.isNaN(startMs) || Number.isNaN(endMs) || endMs <= startMs) {
+        return { content: [{ type: "text", text: jsonOut({ error: "Need a full window with end after start." }) }], isError: true };
+      }
+
+      // The app sends the window in UTC; toISOString() produces that exact format.
+      const startTime = new Date(startMs).toISOString();
+      const endTime = new Date(endMs).toISOString();
+      const path = `/core-details-bff/v2/sleep-details/${sleep.activityId}`;
+      const body: Record<string, unknown> = { start_time: startTime, end_time: endTime };
+      if (resolve_overlaps !== undefined) body.resolve_overlaps = resolve_overlaps;
+
+      if (!confirm) {
+        return { content: [{ type: "text", text: jsonOut(preview("PUT", path, body)) }] };
+      }
+
+      await client.put(path, body);
+      const out = SleepEditOut.parse({ edited: true as const, activity_id: sleep.activityId, start: startTime, end: endTime });
+      return { content: [{ type: "text", text: jsonOut(out) }] };
+    },
+  );
+}

--- a/tests/tools/sleep_edit.test.ts
+++ b/tests/tools/sleep_edit.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { sleepActivity } from "../../src/tools/v2/sleep_edit.js";
+
+describe("sleepActivity", () => {
+  it("extracts activity_id + window from the deep-dive header", () => {
+    const raw = {
+      header_section: {
+        destination: {
+          parameters: {
+            activity_id: "abc-123",
+            start_time: "2026-06-12T23:40:00.000Z",
+            end_time: "2026-06-13T07:15:00.000Z",
+          },
+        },
+      },
+    };
+    expect(sleepActivity(raw)).toEqual({
+      activityId: "abc-123",
+      start: "2026-06-12T23:40:00.000Z",
+      end: "2026-06-13T07:15:00.000Z",
+    });
+  });
+
+  it("returns nulls when the shape is absent", () => {
+    expect(sleepActivity({})).toEqual({ activityId: null, start: null, end: null });
+    expect(sleepActivity(null)).toEqual({ activityId: null, start: null, end: null });
+  });
+});


### PR DESCRIPTION
hi, i hope you accept ai generated prs. 

i've added another command to allow manually editing sleep time: whoop often thinks i'm in bed while i'm actually just on the sofa with a laptop - so i'm using other signals to manually edit time in bed.

----


Adds a write tool that changes a sleep's window. It resolves the sleep's activity_id from the deep-dive, then sends

    PUT /core-details-bff/v2/sleep-details/{activityId}

with a `{start_time, end_time, resolve_overlaps?}` JSON body, using the existing preview-first write-safety harness (preview unless confirm:true). An omitted bound keeps the current value, and `resolve_overlaps:true` handles a new window that overlaps an adjacent sleep/nap.

The endpoint was determined by decompiling the WHOOP Android app v5.455.0 (`AddActivitiesApi.editSleep`); the prior mitmproxy captures never recorded an Edit Sleep request. The verb (PUT, not POST) was confirmed against retrofit2's own annotation parser, since R8 obfuscates the `retrofit2.http.*` annotation class names.

Two deliberate choices worth noting:

- Timestamps are converted to UTC (`Date.toISOString()`) before sending. The app serializes the window in UTC, so matching it keeps the wire format identical and sidesteps any server-side offset handling.
- The confirm:false preview resolves the real activity_id via a read-only GET so it can show the exact request, unlike sibling write tools whose previews are self-contained. The trade is that preview needs a valid token, in exchange for a truthful preview of a mutating call.