### PR TITLE
fix(http): evict idle MCP sessions to stop unbounded memory growth

### DIFF
--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -63,14 +63,31 @@ export async function startHttpServer(client: WhoopClient, opts: HttpServerOptio
 
   // One McpServer + transport pair per active session (MCP spec: a server can't
   // be re-initialized once initialize() runs). Routed by mcp-session-id header.
-  const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+  type Session = { server: McpServer; transport: StreamableHTTPServerTransport; lastSeen: number };
+  const sessions = new Map<string, Session>();
 
-  async function getOrCreateSession(
-    existingSessionId: string | undefined,
-  ): Promise<{ server: McpServer; transport: StreamableHTTPServerTransport }> {
+  // transport.onclose is the only other reclaim path, and clients that never send
+  // DELETE (scheduled/headless MCP clients, reconnects) never fire it — so without
+  // this sweep the map grows one McpServer + full tool registration at a time
+  // until the host OOMs. Seen in production on a 256 MB VM: ~3 days to SIGKILL.
+  const SESSION_IDLE_MS = 30 * 60_000;
+  const sweep = setInterval(() => {
+    const cutoff = Date.now() - SESSION_IDLE_MS;
+    for (const [id, entry] of [...sessions]) {
+      if (entry.lastSeen > cutoff) continue;
+      sessions.delete(id);
+      void entry.transport.close().catch(() => undefined);
+    }
+  }, 5 * 60_000);
+  sweep.unref();
+
+  async function getOrCreateSession(existingSessionId: string | undefined): Promise<Session> {
     if (existingSessionId) {
       const existing = sessions.get(existingSessionId);
-      if (existing) return existing;
+      if (existing) {
+        existing.lastSeen = Date.now();
+        return existing;
+      }
     }
     const newId = randomUUID();
     const newServer = new McpServer({ name: "totem", version: "1.4.4" });
@@ -83,7 +100,7 @@ export async function startHttpServer(client: WhoopClient, opts: HttpServerOptio
       sessions.delete(newId);
     };
     await newServer.connect(newTransport as Parameters<typeof newServer.connect>[0]);
-    const entry = { server: newServer, transport: newTransport };
+    const entry: Session = { server: newServer, transport: newTransport, lastSeen: Date.now() };
     sessions.set(newId, entry);
     return entry;
   }


### PR DESCRIPTION
## Problem

In `src/server-http.ts`, every request arriving without a known `mcp-session-id` allocates a fresh `McpServer` plus a full `registerTools()` pass (48 tools, each with its zod schema and closures). The only reclaim path is `transport.onclose`:

```ts
newTransport.onclose = (): void => {
  sessions.delete(newId);
};
```

HTTP clients that never send `DELETE` — scheduled/headless MCP clients, ordinary reconnects — never fire that callback. With `enableJsonResponse: true` there's no long-lived stream whose teardown would trigger it either. The result is that `sessions` has **no TTL, no size cap, and no sweeper**, so it grows monotonically for the life of the process.

## Evidence

Hit this running the HTTP transport on a 256 MB Fly.io VM (which exposes only ~207 MB to userspace):

```
[293071.434306] Out of memory: Killed process 641 (MainThread)
                total-vm:9646028kB, anon-rss:147892kB
INFO Process appears to have been OOM killed!

exit_code=137, oom_killed=true, requested_stop=false
```

`node dist/server.js` sits at a ~128 MB baseline, crept to ~148 MB RSS over ~3.4 days of uptime (matching the kernel clock at kill time), and was SIGKILLed — recurring on a roughly 3-day cycle. The failure is worse than a clean crash: for a while *before* the kill the machine is memory-starved and the proxy logs

```
could not finish reading HTTP body from instance
```

which surfaces to MCP clients as request timeouts rather than an actionable error, so the server looks intermittently "down" and then mysteriously healthy again after the auto-restart.

## Fix

Track `lastSeen` per session and sweep entries idle for 30 minutes, on a 5-minute interval:

- The interval is `unref()`'d, so it never holds the event loop open (stdio mode and tests are unaffected).
- Iteration is over a copy (`[...sessions]`), so deleting during the sweep is safe.
- `transport.close()` is fire-and-forget via `void ... .catch()`; its `onclose` also removes the entry, which is harmless after the explicit `delete`.
- `lastSeen` is refreshed on every session hit, so active sessions are never evicted.

Eviction degrades exactly the way an unknown session id already does today: the client transparently gets a fresh session. That path is already exercised whenever the server restarts.

The 30-minute idle window is deliberately generous — long enough that it can't disturb an in-use session, short enough to bound growth.

## Testing

- `totem typecheck` — clean
- `totem test` — 238/238 passing (17 files), including `tests/whoop/http_auth.test.ts`, which exercises this transport
- Deployed and verified in production: the compiled sweep is present in the running image and the server is serving normally

## Note

I did not add a unit test for the eviction itself. Doing it properly needs fake timers driving a real HTTP server through a 30-minute window, and `SESSION_IDLE_MS` isn't currently injectable — the test would be timing-sensitive and, in my judgement, more likely to become flaky than to catch a regression. Happy to add one if you'd prefer, and equally happy to make the interval configurable (env var or an `HttpServerOptions` field) if you'd rather it be tunable per deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
