### PR TITLE
fix: project current WHOOP Smart Alarm schedule fields

### DIFF
--- a/src/projections/smart_alarm.ts
+++ b/src/projections/smart_alarm.ts
@@ -2,7 +2,8 @@ import type { SmartAlarmOutT } from "../schemas/smart_alarm.js";
 import { isObject, asArray, asBool, asNumber, asString } from "../lib/walk.js";
 
 // Schedule list from /smart-alarm-bff/v1/schedule/all:
-//   alarm_schedule_list[], schedule_enabled
+//   alarm_schedule_list[] with alarm_on + scheduled_days, schedule_enabled.
+// Older responses used enabled + day_of_week_list instead.
 //
 // Preferences from /smart-alarm-service/v1/smartalarm/preferences (documented):
 //   lower_time_bound, recovery_score_goal, sleep_score_goal, weekly_plan_goal,
@@ -32,18 +33,21 @@ export function projectSmartAlarm(input: ProjectSmartAlarmInput): SmartAlarmOutT
   const list = asArray(sched.alarm_schedule_list)
     .map((s) => {
       if (!isObject(s)) return null;
-      const days = asArray(s.day_of_week_list)
+      const rawDays = asArray(s.day_of_week_list);
+      const days = (rawDays.length > 0 ? rawDays : asArray(s.scheduled_days))
         .filter((d): d is string => typeof d === "string")
         .filter((d): d is Day => (VALID_DAYS as readonly string[]).includes(d));
       const mode = asString(s.alarm_mode);
       return {
         schedule_id: asString(s.schedule_id ?? s.id) ?? "",
-        enabled: asBool(s.enabled) ?? false,
+        enabled: asBool(s.enabled) ?? asBool(s.alarm_on) ?? false,
         days_of_week: days,
         latest_wake_time: asString(s.latest_wake_time) ?? "",
         alarm_mode: ((VALID_MODES as readonly string[]).includes(mode ?? "") ? mode : "IN_THE_GREEN") as Mode,
-        sleep_goal: asString(s.sleep_goal),
-        timezone_offset: asString(s.time_zone_offset) ?? "",
+        // The schedule-list response omits these. An empty sleep_goal is the
+        // valid write value for IN_THE_GREEN; the account offset comes from prefs.
+        sleep_goal: asString(s.sleep_goal) ?? "",
+        timezone_offset: asString(s.time_zone_offset) ?? asString(prefs.time_zone_offset) ?? "",
       };
     })
     .filter((x): x is NonNullable<typeof x> => x !== null);

--- a/tests/fixtures/smart_alarm_current.json
+++ b/tests/fixtures/smart_alarm_current.json
@@ -1,0 +1,21 @@
+{
+  "schedules": {
+    "schedule_enabled": true,
+    "alarm_schedule_list": [
+      {
+        "schedule_id": "00000000-0000-4000-8000-000000000001",
+        "alarm_mode": "IN_THE_GREEN",
+        "alarm_on": true,
+        "scheduled_days": ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+        "latest_wake_time": "6:25 AM"
+      }
+    ]
+  },
+  "preferences": {
+    "lower_time_bound": "05:25:00",
+    "upper_time_bound": "06:25:00",
+    "goal": "IN_THE_GREEN",
+    "time_zone_offset": "-0400",
+    "weekly_plan_goal": 0
+  }
+}

--- a/tests/projections/smart_alarm.test.ts
+++ b/tests/projections/smart_alarm.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { projectSmartAlarm } from "../../src/projections/smart_alarm.js";
+import { SmartAlarmOut } from "../../src/schemas/smart_alarm.js";
+
+const load = (): unknown => JSON.parse(readFileSync(resolve("tests/fixtures", "smart_alarm_current.json"), "utf8"));
+
+describe("projectSmartAlarm — current schedule-list response", () => {
+  const input = load() as Parameters<typeof projectSmartAlarm>[0];
+  const out = projectSmartAlarm(input);
+
+  it("parses the output schema", () => {
+    expect(() => SmartAlarmOut.parse(out)).not.toThrow();
+  });
+
+  it("uses alarm_on and scheduled_days from the current WHOOP response", () => {
+    expect(out.schedules[0]).toMatchObject({
+      enabled: true,
+      days_of_week: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+      latest_wake_time: "6:25 AM",
+    });
+  });
+
+  it("backfills write-safe defaults omitted by the schedule list", () => {
+    expect(out.schedules[0]).toMatchObject({ sleep_goal: "", timezone_offset: "-0400" });
+  });
+});


### PR DESCRIPTION
Updates the Smart Alarm projection for the current `alarm_on` and `scheduled_days` response shape, while preserving legacy compatibility.

Verification: `npx tsc --noEmit`; `npx vitest run tests/projections/smart_alarm.test.ts`.