### PR TITLE
fix: validate configured timezones and resolve DST wall times

### DIFF
--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -49,11 +49,11 @@ export function getProfileTimezone(): string | null {
  *   3. Server's system timezone (Intl default — UTC inside Docker / Fly)
  */
 export function getTimezone(): string {
-  return (
-    process.env.WHOOP_TIMEZONE
-    ?? cachedProfileTz
-    ?? Intl.DateTimeFormat().resolvedOptions().timeZone
-  );
+  const systemTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  for (const candidate of [process.env.WHOOP_TIMEZONE, cachedProfileTz, systemTz, "UTC"]) {
+    if (candidate && isValidTimezone(candidate)) return candidate;
+  }
+  return "UTC";
 }
 
 export function isUtcIso(s: string): boolean {
@@ -100,8 +100,22 @@ export function wallClockIso(
   minute: number,
   tz: string = getTimezone(),
 ): string {
-  const ref = new Date(`${date}T${pad2(hour)}:${pad2(minute)}:00Z`);
-  const offset = Number.isNaN(ref.getTime()) ? "+00:00" : offsetAt(ref, tz);
+  const wallAsUtc = new Date(`${date}T${pad2(hour)}:${pad2(minute)}:00Z`);
+  if (Number.isNaN(wallAsUtc.getTime()) || !isValidTimezone(tz)) {
+    return `${date}T${pad2(hour)}:${pad2(minute)}:00+00:00`;
+  }
+  // Resolve the offset at the represented local wall-clock instant, not at the
+  // same clock fields interpreted as UTC. Iterate because crossing a DST
+  // boundary can change the first candidate's offset (e.g. 03:30 on spring day).
+  let offset = offsetAt(wallAsUtc, tz);
+  for (let i = 0; i < 3; i++) {
+    const sign = offset[0] === "-" ? -1 : 1;
+    const offsetMinutes = sign * (Number(offset.slice(1, 3)) * 60 + Number(offset.slice(4, 6)));
+    const candidateInstant = new Date(wallAsUtc.getTime() - offsetMinutes * 60_000);
+    const next = offsetAt(candidateInstant, tz);
+    if (next === offset) break;
+    offset = next;
+  }
   return `${date}T${pad2(hour)}:${pad2(minute)}:00${offset}`;
 }
 
@@ -122,7 +136,19 @@ export function clockLabelToMinutes(label: string | null): number | null {
 function parseFixedOffset(s: string): { sign: "+" | "-"; hh: string; mm: string } | null {
   const m = s.match(FIXED_OFFSET_RE);
   if (!m) return null;
+  if (Number(m[2]) > 23 || Number(m[3]) > 59) return null;
   return { sign: m[1] as "+" | "-", hh: m[2]!, mm: m[3]! };
+}
+
+/** Whether a configured timezone is a supported IANA name or fixed offset. */
+export function isValidTimezone(tz: string): boolean {
+  if (parseFixedOffset(tz)) return true;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz }).format();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -218,7 +244,10 @@ export function localizeTimestamps<T>(value: T, tz: string = getTimezone()): T {
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
-      out[k] = localizeTimestamps(v, tz);
+      // Fields explicitly named *_utc are wire-level / audit values. Their
+      // literal UTC form matters (for example write previews show precisely
+      // what will be sent to Whoop), so do not turn them back into local time.
+      out[k] = k.endsWith("_utc") ? v : localizeTimestamps(v, tz);
     }
     return out as T;
   }

--- a/src/whoop/init_timezone.ts
+++ b/src/whoop/init_timezone.ts
@@ -14,7 +14,7 @@
 // without restarting the server.
 
 import type { WhoopClient } from "./client.js";
-import { setProfileTimezone } from "../lib/timezone.js";
+import { isValidTimezone, setProfileTimezone } from "../lib/timezone.js";
 
 const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
@@ -25,7 +25,7 @@ async function fetchProfileTimezone(client: WhoopClient): Promise<string | null>
     const profile = (bootstrap as Record<string, unknown>).profile;
     if (!profile || typeof profile !== "object") return null;
     const offset = (profile as Record<string, unknown>).timezone_offset;
-    return typeof offset === "string" && offset.length > 0 ? offset : null;
+    return typeof offset === "string" && isValidTimezone(offset) ? offset : null;
   } catch {
     return null;
   }
@@ -42,7 +42,7 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
  * to spend API calls keeping the cache warm.
  */
 export function startTimezoneAutoDetect(client: WhoopClient): void {
-  if (process.env.WHOOP_TIMEZONE) return;
+  if (process.env.WHOOP_TIMEZONE && isValidTimezone(process.env.WHOOP_TIMEZONE)) return;
 
   if (refreshTimer) clearInterval(refreshTimer);
 

--- a/tests/lib/timezone.test.ts
+++ b/tests/lib/timezone.test.ts
@@ -7,6 +7,8 @@ import {
   setProfileTimezone,
   getProfileTimezone,
   zonedParts,
+  wallClockIso,
+  isValidTimezone,
 } from "../../src/lib/timezone.js";
 import { isoDay } from "../../src/lib/dates.js";
 
@@ -185,6 +187,16 @@ describe("localizeTimestamps", () => {
     expect(localizeTimestamps("2026-05-25T22:30:00Z", "America/Los_Angeles"))
       .toBe("2026-05-25T15:30:00-07:00");
   });
+
+  it("preserves explicitly UTC-labelled wire timestamps", () => {
+    expect(localizeTimestamps({
+      start: "2026-05-25T22:30:00.000Z",
+      sent_start_utc: "2026-05-25T22:30:00.000Z",
+    }, "America/Los_Angeles")).toEqual({
+      start: "2026-05-25T15:30:00.000-07:00",
+      sent_start_utc: "2026-05-25T22:30:00.000Z",
+    });
+  });
 });
 
 describe("toLocalIso with fixed offset (Whoop profile.timezone_offset form)", () => {
@@ -247,6 +259,24 @@ describe("getTimezone priority chain", () => {
     expect(getTimezone()).toBe("-0700");
   });
 
+  it("treats empty WHOOP_TIMEZONE as unset (dotenv `WHOOP_TIMEZONE=` line)", () => {
+    process.env.WHOOP_TIMEZONE = "";
+    setProfileTimezone("-0400");
+    expect(getTimezone()).toBe("-0400");
+  });
+
+  it("keeps live-state/sleep timestamp serialization working with a blank env override", () => {
+    process.env.WHOOP_TIMEZONE = "";
+    setProfileTimezone("-0400");
+    expect(localizeTimestamps({
+      state: "SLEEPING",
+      last_updated_at: "2026-08-24T12:00:00Z",
+    })).toEqual({
+      state: "SLEEPING",
+      last_updated_at: "2026-08-24T08:00:00-04:00",
+    });
+  });
+
   it("falls back to system TZ when env var unset and profile not cached", () => {
     // Don't assert exact system TZ (varies by CI host) — just confirm it
     // returns SOMETHING valid and not our cached/env values.
@@ -254,5 +284,25 @@ describe("getTimezone priority chain", () => {
     expect(typeof tz).toBe("string");
     expect(tz.length).toBeGreaterThan(0);
     expect(tz).not.toBe("-0700");
+  });
+
+  it("ignores invalid env and profile timezone values", () => {
+    process.env.WHOOP_TIMEZONE = "Not/A_Timezone";
+    setProfileTimezone("+9960");
+    expect(isValidTimezone(process.env.WHOOP_TIMEZONE)).toBe(false);
+    expect(isValidTimezone("+9960")).toBe(false);
+    expect(() => new Intl.DateTimeFormat("en-US", { timeZone: getTimezone() })).not.toThrow();
+  });
+});
+
+describe("wallClockIso DST resolution", () => {
+  it("uses the post-transition offset after the spring-forward gap", () => {
+    expect(wallClockIso("2026-03-08", 3, 30, "America/Los_Angeles"))
+      .toBe("2026-03-08T03:30:00-07:00");
+  });
+
+  it("uses the pre-transition offset before spring-forward", () => {
+    expect(wallClockIso("2026-03-08", 1, 30, "America/Los_Angeles"))
+      .toBe("2026-03-08T01:30:00-08:00");
   });
 });


### PR DESCRIPTION
Validates configured/profile timezones, ignores blank or invalid overrides, and resolves local wall-clock offsets correctly across DST transitions.

Verification: `npx tsc --noEmit`; `npx vitest run tests/lib/timezone.test.ts`.