### PR TITLE
fix: harden authentication refresh and persistence

### DIFF
--- a/src/whoop/cognito.ts
+++ b/src/whoop/cognito.ts
@@ -9,6 +9,7 @@
 //   3. Get AccessToken + RefreshToken from AuthenticationResult
 //   4. To refresh: InitiateAuth with REFRESH_TOKEN_AUTH (no MFA needed)
 import { randomUUID } from "node:crypto";
+import { REQUEST_TIMEOUT_MS } from "./constants.js";
 
 const ENDPOINT = "https://api.prod.whoop.com/auth-service/v3/whoop/";
 const USER_AGENT =
@@ -53,20 +54,33 @@ async function callCognito(
   target: "InitiateAuth" | "RespondToAuthChallenge",
   body: object,
 ): Promise<CognitoResponse> {
-  const response = await fetch(ENDPOINT, {
-    method: "POST",
-    headers: {
-      "content-type": "application/x-amz-json-1.1",
-      "x-amz-target": `AWSCognitoIdentityProviderService.${target}`,
-      "amz-sdk-request": "attempt=1; max=1",
-      "amz-sdk-invocation-id": randomUUID(),
-      "user-agent": USER_AGENT,
-      accept: "*/*",
-      "accept-encoding": "gzip, deflate, br",
-      "accept-language": "en-US,en;q=0.9",
-    },
-    body: JSON.stringify(body),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-amz-json-1.1",
+        "x-amz-target": `AWSCognitoIdentityProviderService.${target}`,
+        "amz-sdk-request": "attempt=1; max=1",
+        "amz-sdk-invocation-id": randomUUID(),
+        "user-agent": USER_AGENT,
+        accept: "*/*",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-US,en;q=0.9",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Cognito ${target} timed out after ${REQUEST_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
   const text = await response.text();
   if (!response.ok) {
     let detail = text.slice(0, 200);

--- a/src/whoop/installation.ts
+++ b/src/whoop/installation.ts
@@ -30,17 +30,38 @@ export function resolveInstallationId(envPath: string): string {
   const existing = process.env.WHOOP_INSTALLATION_ID;
   if (existing) return existing;
 
+  // Usually dotenv has already populated process.env, but reading the persisted
+  // value here makes the helper independently idempotent and protects callers
+  // that invoke it before loading the env file.
+  try {
+    if (existsSync(envPath)) {
+      const persistedId = readFileSync(envPath, "utf8")
+        .split("\n")
+        .filter((candidate) => candidate.startsWith("WHOOP_INSTALLATION_ID="))
+        .map((candidate) => candidate.slice("WHOOP_INSTALLATION_ID=".length).trim())
+        .filter(Boolean)
+        .at(-1);
+      if (persistedId) {
+        process.env.WHOOP_INSTALLATION_ID = persistedId;
+        return persistedId;
+      }
+    }
+  } catch {
+    // Fall through to generation + best-effort persistence.
+  }
+
   // The app sends an uppercase UUID; match its shape.
   let id = randomUUID().toUpperCase();
   let persisted = false;
   try {
     if (existsSync(envPath)) {
-      const lines = readFileSync(envPath, "utf8").split("\n");
-      if (!lines.some((l) => l.startsWith("WHOOP_INSTALLATION_ID="))) {
-        lines.push(`WHOOP_INSTALLATION_ID=${id}`);
-        writeFileSync(envPath, lines.join("\n"), { mode: 0o600 });
-        try { chmodSync(envPath, 0o600); } catch { /* best-effort */ }
-      }
+      const lines = readFileSync(envPath, "utf8")
+        .split("\n")
+        .filter((line) => !line.startsWith("WHOOP_INSTALLATION_ID="));
+      const entry = `WHOOP_INSTALLATION_ID=${id}`;
+      lines.push(entry);
+      writeFileSync(envPath, lines.join("\n"), { mode: 0o600 });
+      try { chmodSync(envPath, 0o600); } catch { /* best-effort */ }
       persisted = true;
     }
   } catch {

--- a/src/whoop/token_manager.ts
+++ b/src/whoop/token_manager.ts
@@ -71,6 +71,11 @@ export class TokenManager {
       console.error("[totem] Cognito rotated the refresh token — persisting the new one.");
     }
     this.expiresAt = next.expiresAt;
-    this.store.save({ accessToken: this.accessToken, refreshToken: this.refreshToken });
+    try {
+      this.store.save({ accessToken: this.accessToken, refreshToken: this.refreshToken });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`[totem] refreshed the Whoop access token but could not persist it: ${detail}. This process will keep using the fresh in-memory token.`);
+    }
   }
 }

--- a/tests/whoop/cognito.test.ts
+++ b/tests/whoop/cognito.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { refreshCognitoSession } from "../../src/whoop/cognito.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Cognito request timeout", () => {
+  it("aborts a refresh that never receives a response", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn((_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+    })));
+    const pending = refreshCognitoSession("test@example.com", "refresh-token");
+    const expectation = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expectation;
+  });
+});

--- a/tests/whoop/installation.test.ts
+++ b/tests/whoop/installation.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveInstallationId } from "../../src/whoop/installation.js";
+
+const originalId = process.env.WHOOP_INSTALLATION_ID;
+const originalEmail = process.env.WHOOP_EMAIL;
+const dirs: string[] = [];
+
+afterEach(() => {
+  if (originalId === undefined) delete process.env.WHOOP_INSTALLATION_ID;
+  else process.env.WHOOP_INSTALLATION_ID = originalId;
+  if (originalEmail === undefined) delete process.env.WHOOP_EMAIL;
+  else process.env.WHOOP_EMAIL = originalEmail;
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolveInstallationId", () => {
+  it("replaces a blank env entry and reuses the persisted ID after restart", () => {
+    const dir = mkdtempSync(join(tmpdir(), "totem-installation-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    writeFileSync(envPath, "WHOOP_INSTALLATION_ID=\nWHOOP_EMAIL=test@example.com\n");
+    delete process.env.WHOOP_INSTALLATION_ID;
+    process.env.WHOOP_EMAIL = "test@example.com";
+
+    const first = resolveInstallationId(envPath);
+    expect(readFileSync(envPath, "utf8")).toContain(`WHOOP_INSTALLATION_ID=${first}`);
+    delete process.env.WHOOP_INSTALLATION_ID;
+    const second = resolveInstallationId(envPath);
+    expect(second).toBe(first);
+  });
+
+  it("deduplicates blank installation-ID entries while persisting", () => {
+    const dir = mkdtempSync(join(tmpdir(), "totem-installation-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    writeFileSync(envPath, "WHOOP_INSTALLATION_ID=\nWHOOP_INSTALLATION_ID=\n");
+    delete process.env.WHOOP_INSTALLATION_ID;
+    process.env.WHOOP_EMAIL = "test@example.com";
+    const id = resolveInstallationId(envPath);
+    const idLines = readFileSync(envPath, "utf8").split("\n").filter((line) => line.startsWith("WHOOP_INSTALLATION_ID="));
+    expect(idLines).toEqual([`WHOOP_INSTALLATION_ID=${id}`]);
+  });
+});

--- a/tests/whoop/token_manager.test.ts
+++ b/tests/whoop/token_manager.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/whoop/cognito.js", () => ({
+  decodeJwtExp: () => 0,
+  refreshCognitoSession: vi.fn().mockResolvedValue({
+    accessToken: "fresh-access",
+    refreshToken: "fresh-refresh",
+    idToken: "id",
+    expiresAt: Date.now() + 3_600_000,
+  }),
+}));
+
+import { TokenManager } from "../../src/whoop/token_manager.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("TokenManager persistence failures", () => {
+  it("keeps using a successfully refreshed in-memory token when persistence fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const manager = new TokenManager({
+      email: "test@example.com",
+      accessToken: "expired",
+      refreshToken: "old-refresh",
+      store: { save: () => { throw new Error("read-only filesystem"); } },
+    });
+    await expect(manager.getToken()).resolves.toBe("fresh-access");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("could not persist"));
+  });
+});


### PR DESCRIPTION
Adds Cognito request timeouts, repairs persisted installation IDs, and keeps a refreshed token usable if persistence fails.

OAuth resource-claim enforcement remains log-only until it has been validated against a live claude.ai connector.

Verification: `npx tsc --noEmit`; targeted auth tests.