### PR TITLE
feat: add bounded cache for safe WHOOP reads

### DIFF
--- a/src/tools/v2/raw.ts
+++ b/src/tools/v2/raw.ts
@@ -41,6 +41,7 @@ export function registerRaw(server: McpServer, client: WhoopClient): void {
           response = await client.delete(safePath, query ?? {});
           break;
       }
+      if (isMutate) client.invalidateAll();
       // The client throws on non-2xx, so reaching here means success; it doesn't
       // surface the exact code, so 200 stands in for any 2xx (incl. 201/204).
       const out = RawOut.parse({ path: safePath, method, status: 200, response });

--- a/src/whoop/client.ts
+++ b/src/whoop/client.ts
@@ -1,5 +1,6 @@
 import { BASE_URL, API_VERSION, REQUEST_TIMEOUT_MS } from "./constants.js";
 import { deviceHeaders } from "./device.js";
+import { isoDay } from "../lib/dates.js";
 import {
   WhoopApiError,
   WhoopAuthExpiredError,
@@ -139,7 +140,11 @@ function cachePolicy(
   // than in a query parameter. Treat them consistently with query-based reads.
   const pathDate = path.match(/\/(\d{4}-\d{2}-\d{2})(?:\/|$)/)?.[1];
   const dateHint = typeof suppliedDate === "string" ? suppliedDate.slice(0, 10) : pathDate;
-  const historical = Boolean(dateHint && dateHint < new Date(now()).toISOString().slice(0, 10));
+  // Dates represent the member's day, not UTC server time. Current-day reads
+  // use the following bounded TTLs: home 30s; activity 60s; recovery, sleep,
+  // trends, lifts, communities and journal 5m; calendar 15m; settings 10m.
+  // Historical reads may use their longer endpoint-specific TTLs below.
+  const historical = Boolean(dateHint && dateHint < isoDay(new Date(now())));
   // Freshness-sensitive endpoints must never return a completed cached value.
   if (
     path === "/health-tab-bff/v1/health-tab" ||

--- a/src/whoop/client.ts
+++ b/src/whoop/client.ts
@@ -9,18 +9,199 @@ import {
 export interface WhoopClientConfig {
   /** Async function returning a fresh bearer token. Called before each request. */
   getToken: () => Promise<string>;
+  /** Injectable clock for deterministic cache tests. */
+  now?: () => number;
 }
 
 type QueryValue = string | number | boolean | undefined | null;
 
+type CacheEntry = {
+  value: unknown;
+  expiresAt: number;
+  bytes: number;
+  tags: readonly string[];
+};
+
+const MAX_CACHE_ENTRIES = 100;
+const MAX_CACHE_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Process-local LRU for safe GET results. It deliberately never persists data,
+ * and only keeps completed values for endpoints with an explicit TTL policy.
+ */
+class RequestCache {
+  private readonly values = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+  private bytes = 0;
+
+  constructor(private readonly now: () => number) {}
+
+  async getOrLoad<T>(
+    key: string,
+    policy: { ttlMs: number; tags: readonly string[] } | null,
+    load: () => Promise<T>,
+  ): Promise<T> {
+    const cached = this.values.get(key);
+    if (cached) {
+      if (cached.expiresAt > this.now()) {
+        // Map insertion order is the LRU order.
+        this.values.delete(key);
+        this.values.set(key, cached);
+        return cached.value as T;
+      }
+      this.delete(key, cached);
+    }
+
+    // Even live endpoints share an already-running identical request, but their
+    // completed values are never retained.
+    const existing = this.inFlight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const pending = load()
+      .then((value) => {
+        // Pending activities are mutable server-side objects; serving one after
+        // Whoop finishes scoring it would be misleading.
+        if (policy && !containsPendingState(value)) this.store(key, value, policy);
+        return value;
+      })
+      .finally(() => this.inFlight.delete(key));
+    this.inFlight.set(key, pending);
+    return pending;
+  }
+
+  invalidate(tags: readonly string[]): void {
+    if (tags.includes("all")) {
+      this.values.clear();
+      this.bytes = 0;
+      return;
+    }
+    for (const [key, entry] of this.values) {
+      if (entry.tags.some((tag) => tags.includes(tag))) this.delete(key, entry);
+    }
+  }
+
+  private store(key: string, value: unknown, policy: { ttlMs: number; tags: readonly string[] }): void {
+    let bytes = 0;
+    try {
+      bytes = Buffer.byteLength(JSON.stringify(value));
+    } catch {
+      return; // Never let cache accounting affect a successful API response.
+    }
+    if (bytes > MAX_CACHE_BYTES) return;
+    const existing = this.values.get(key);
+    if (existing) this.delete(key, existing);
+    const entry: CacheEntry = {
+      value,
+      expiresAt: this.now() + policy.ttlMs,
+      bytes,
+      tags: policy.tags,
+    };
+    this.values.set(key, entry);
+    this.bytes += bytes;
+    while (this.values.size > MAX_CACHE_ENTRIES || this.bytes > MAX_CACHE_BYTES) {
+      const oldest = this.values.entries().next().value as [string, CacheEntry] | undefined;
+      if (!oldest) break;
+      this.delete(oldest[0], oldest[1]);
+    }
+  }
+
+  private delete(key: string, entry: CacheEntry): void {
+    this.values.delete(key);
+    this.bytes -= entry.bytes;
+  }
+}
+
+function containsPendingState(value: unknown): boolean {
+  try {
+    return JSON.stringify(value).toLowerCase().includes('"pending"');
+  } catch {
+    return true;
+  }
+}
+
+function cacheKey(path: string, query: Record<string, QueryValue>): string {
+  const params = Object.entries(query)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join("&");
+  return `${path}?${params}`;
+}
+
+function cachePolicy(
+  path: string,
+  query: Record<string, QueryValue>,
+  now: () => number,
+): { ttlMs: number; tags: readonly string[] } | null {
+  const suppliedDate = [query.date, query.endDate, query.end]
+    .find((value): value is string | number | boolean => value !== undefined && value !== null);
+  // Some APIs put their date in the path (for example weekly-plan), rather
+  // than in a query parameter. Treat them consistently with query-based reads.
+  const pathDate = path.match(/\/(\d{4}-\d{2}-\d{2})(?:\/|$)/)?.[1];
+  const dateHint = typeof suppliedDate === "string" ? suppliedDate.slice(0, 10) : pathDate;
+  const historical = Boolean(dateHint && dateHint < new Date(now()).toISOString().slice(0, 10));
+  // Freshness-sensitive endpoints must never return a completed cached value.
+  if (
+    path === "/health-tab-bff/v1/health-tab" ||
+    path === "/activities-service/v1/user-state" ||
+    path.startsWith("/health-service/v2/stress-bff/")
+  ) return null;
+
+  if (path === "/home-service/v1/home") return { ttlMs: historical ? 60 * 60_000 : 30_000, tags: ["daily"] };
+  if (path.includes("calendar/")) return { ttlMs: historical ? 12 * 60 * 60_000 : 15 * 60_000, tags: ["calendar", "daily"] };
+  if (path.includes("deep-dive/recovery") || path === "/developer/v2/recovery") {
+    return { ttlMs: historical ? 60 * 60_000 : 5 * 60_000, tags: ["recovery", "daily"] };
+  }
+  if (path.includes("deep-dive/sleep") || path === "/developer/v2/activity/sleep") {
+    return { ttlMs: historical ? 60 * 60_000 : 5 * 60_000, tags: ["sleep", "daily"] };
+  }
+  if (path.includes("sleepneed")) return { ttlMs: 60_000, tags: ["sleep_plan", "daily"] };
+  if (path.includes("progression-service")) return { ttlMs: historical ? 60 * 60_000 : 5 * 60_000, tags: ["trend"] };
+  if (path.includes("activity/workout") || path.includes("cardio-details")) {
+    return { ttlMs: historical ? 15 * 60_000 : 60_000, tags: ["activity", "daily"] };
+  }
+  if (path.includes("weightlifting-service")) return { ttlMs: 5 * 60_000, tags: ["lift"] };
+  if (path.includes("community-service")) return { ttlMs: 5 * 60_000, tags: ["community"] };
+  if (
+    path.includes("bootstrap") ||
+    path.includes("hidden-metrics") ||
+    path.includes("stealth-mode") ||
+    path.includes("hr-zones") ||
+    path.includes("smart-alarm")
+  ) return { ttlMs: 10 * 60_000, tags: ["settings", "profile"] };
+  if (path.includes("journal-service")) return { ttlMs: 5 * 60_000, tags: ["journal", "daily"] };
+  return null;
+}
+
+function writeInvalidationTags(path: string): readonly string[] {
+  if (
+    path.includes("create-activity") || path.includes("cardio-details") || path.includes("sleep-details")
+  ) return ["activity", "daily", "sleep", "recovery", "sleep_plan", "calendar"];
+  if (path.includes("journal-service") || path.includes("menstrual") || path.includes("symptom")) {
+    return ["journal", "daily", "recovery", "sleep"];
+  }
+  if (path.includes("weightlifting-service")) return ["lift", "activity", "daily"];
+  if (path.includes("profile-service") || path.includes("hr-zones") || path.includes("smart-alarm") || path.includes("hidden-metrics")) {
+    return ["settings", "profile", "daily", "sleep_plan"];
+  }
+  // whoop_raw can mutate any undocumented endpoint.
+  return ["all"];
+}
+
 export class WhoopClient {
-  constructor(private readonly config: WhoopClientConfig) {}
+  private readonly cache: RequestCache;
+
+  constructor(private readonly config: WhoopClientConfig) {
+    this.cache = new RequestCache(config.now ?? Date.now);
+  }
 
   async get<T = unknown>(
     path: string,
     query: Record<string, QueryValue> = {},
   ): Promise<T> {
-    return this.request<T>("GET", path, query, undefined);
+    return this.cache.getOrLoad(cacheKey(path, query), cachePolicy(path, query, this.config.now ?? Date.now), () =>
+      this.request<T>("GET", path, query, undefined),
+    );
   }
 
   async post<T = unknown>(
@@ -44,6 +225,11 @@ export class WhoopClient {
     query: Record<string, QueryValue> = {},
   ): Promise<T> {
     return this.request<T>("DELETE", path, query, undefined);
+  }
+
+  /** Raw writes can target unknown resources, so callers may flush all state. */
+  invalidateAll(): void {
+    this.cache.invalidate(["all"]);
   }
 
   private async request<T>(
@@ -110,9 +296,8 @@ export class WhoopClient {
       throw new WhoopApiError(response.status, path, text, description);
     }
 
-    if (response.status === 204) {
-      return undefined as T;
-    }
-    return (await response.json()) as T;
+    const result = response.status === 204 ? undefined as T : (await response.json()) as T;
+    if (method !== "GET") this.cache.invalidate(writeInvalidationTags(path));
+    return result;
   }
 }

--- a/tests/whoop/client.test.ts
+++ b/tests/whoop/client.test.ts
@@ -123,6 +123,23 @@ describe("WhoopClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("uses the member's configured timezone when deciding whether a date is historical", async () => {
+    const previousTimezone = process.env.WHOOP_TIMEZONE;
+    process.env.WHOOP_TIMEZONE = "America/Los_Angeles";
+    try {
+      let now = Date.parse("2026-08-24T01:00:00.000Z"); // Aug 23 in Los Angeles
+      fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ score: 1 }), { status: 200 })));
+      const client = new WhoopClient({ getToken: async () => "test-bearer", now: () => now });
+      await client.get("/home-service/v1/home", { date: "2026-08-23" });
+      now += 30_001;
+      await client.get("/home-service/v1/home", { date: "2026-08-23" });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousTimezone === undefined) delete process.env.WHOOP_TIMEZONE;
+      else process.env.WHOOP_TIMEZONE = previousTimezone;
+    }
+  });
+
   it("normalizes query ordering and evicts the least-recently-used entry at 100 values", async () => {
     fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })));
     const client = makeClient();

--- a/tests/whoop/client.test.ts
+++ b/tests/whoop/client.test.ts
@@ -95,4 +95,82 @@ describe("WhoopClient", () => {
     expect(url).not.toContain("b=");
     expect(url).not.toContain("c=");
   });
+
+  it("caches eligible GETs until their TTL expires", async () => {
+    let now = 1_000;
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ score: 1 }), { status: 200 })));
+    const client = new WhoopClient({ getToken: async () => "test-bearer", now: () => now });
+    const today = new Date().toISOString().slice(0, 10);
+    await client.get("/home-service/v1/home", { date: today });
+    await client.get("/home-service/v1/home", { date: today });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    now += 30_001;
+    await client.get("/home-service/v1/home", { date: today });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps date-bearing historical paths longer than current-day paths", async () => {
+    let now = Date.parse("2026-08-24T12:00:00.000Z");
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })));
+    const client = new WhoopClient({ getToken: async () => "test-bearer", now: () => now });
+    await client.get("/progression-service/v2/weekly-plan/home-tile/2026-08-01");
+    now += 6 * 60_000;
+    await client.get("/progression-service/v2/weekly-plan/home-tile/2026-08-01");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await client.get("/progression-service/v2/weekly-plan/home-tile/2026-08-24");
+    now += 6 * 60_000;
+    await client.get("/progression-service/v2/weekly-plan/home-tile/2026-08-24");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("normalizes query ordering and evicts the least-recently-used entry at 100 values", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })));
+    const client = makeClient();
+    await client.get("/home-service/v1/home", { date: "2026-01-01", locale: "en-US" });
+    await client.get("/home-service/v1/home", { locale: "en-US", date: "2026-01-01" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    for (let day = 2; day <= 101; day++) {
+      await client.get("/home-service/v1/home", { date: `2026-01-${String(day).padStart(2, "0")}` });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(101);
+    await client.get("/home-service/v1/home", { date: "2026-01-01", locale: "en-US" });
+    expect(fetchMock).toHaveBeenCalledTimes(102);
+  });
+
+  it("does not retain pending activity records", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ state: "PENDING" }), { status: 200 })));
+    const client = makeClient();
+    await client.get("/developer/v2/activity/workout", { start: "2026-08-01", end: "2026-08-02" });
+    await client.get("/developer/v2/activity/workout", { start: "2026-08-01", end: "2026-08-02" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces simultaneous GETs but never caches completed live values", async () => {
+    let resolveFetch!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFetch = resolve; }));
+    const client = makeClient();
+    const first = client.get("/activities-service/v1/user-state");
+    const second = client.get("/activities-service/v1/user-state");
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    resolveFetch(new Response(JSON.stringify({ state: "idle" }), { status: 200 }));
+    await Promise.all([first, second]);
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ state: "workout" }), { status: 200 }));
+    await client.get("/activities-service/v1/user-state");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failures and invalidates dependent GETs after a write", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("fail", { status: 500 }));
+    const client = makeClient();
+    await expect(client.get("/home-service/v1/home", { date: "2026-05-23" })).rejects.toBeInstanceOf(WhoopServerError);
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ score: 1 }), { status: 200 }));
+    await client.get("/home-service/v1/home", { date: "2026-05-23" });
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await client.post("/core-details-bff/v0/create-activity", {});
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ score: 2 }), { status: 200 }));
+    await client.get("/home-service/v1/home", { date: "2026-05-23" });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
 });


### PR DESCRIPTION
Adds a bounded LRU for safe GET responses, coalesces in-flight reads, skips completed caching for live values, and invalidates related values after writes.

Historical-vs-current classification uses the member’s configured timezone. Current-day completed-response TTLs are: home 30s; activity and sleep-need 60s; recovery, sleep, trends, lifts, communities, and journal 5m; calendar 15m; settings 10m. Live HR, live state, and live stress are never retained after completion.

Verification: `npx tsc --noEmit`; `npx vitest run tests/whoop/client.test.ts`.