### PR TITLE
feat: add compact WHOOP overview tools

### DIFF
--- a/src/schemas/compact.ts
+++ b/src/schemas/compact.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { IsoDateTime } from "./primitives.js";
+import { LiveHrOut, LiveStateOut, LiveStressOut } from "./live.js";
+import { StrainOut } from "./strain.js";
+import { SleepNeedOut } from "./sleep_need.js";
+import { TrendOut } from "./trend.js";
+import { WorkoutListOut } from "./workouts.js";
+
+const DailyBriefSleep = z.object({
+  performance_pct: z.number().nullable(),
+  total_sleep_ms: z.number().int().nullable(),
+  time_in_bed_ms: z.number().int().nullable().optional(),
+  efficiency_pct: z.number().nullable(),
+  stages: z.object({
+    rem_ms: z.number().int().nullable(),
+    light_ms: z.number().int().nullable(),
+    sws_ms: z.number().int().nullable(),
+    wake_ms: z.number().int().nullable(),
+  }).optional(),
+  started_at: IsoDateTime.nullable(),
+  ended_at: IsoDateTime.nullable(),
+});
+
+export const DailyBriefOut = z.object({
+  date: z.iso.date(),
+  recovery: z.object({
+    score: z.number().nullable(), state: z.enum(["GREEN", "YELLOW", "RED"]).nullable(),
+    hrv_ms: z.number().nullable(), rhr_bpm: z.number().nullable(),
+  }).optional(),
+  sleep: DailyBriefSleep.optional(),
+  strain: StrainOut.nullable().optional(),
+  sleep_plan: SleepNeedOut.nullable().optional(),
+  activity: z.object({
+    state: z.enum(["workout", "sleep", "idle", "recovery"]).nullable(),
+    sport_name: z.string().nullable(), started_at: IsoDateTime.nullable(),
+  }).optional(),
+});
+
+export const ActivityNowOut = z.object({
+  state: LiveStateOut.nullable(),
+  heart_rate: LiveHrOut.nullable(),
+  stress: LiveStressOut.nullable(),
+});
+
+const TrendSegment = z.object({
+  label: z.enum(["week", "month", "six_month", "year"]),
+  start_date: z.string(), end_date: z.string(), avg: z.number().nullable(),
+  min: z.number().nullable(), max: z.number().nullable(), delta_pct: z.number().nullable(),
+  unit: z.string().nullable(),
+  points: z.array(z.object({ date: z.string(), value: z.number().nullable(), value_display: z.string().nullable() })),
+});
+
+export const TrendPackOut = z.object({
+  end_date: z.iso.date(),
+  window: z.enum(["week", "month", "six_month", "year"]),
+  trends: z.array(z.union([
+    z.object({ metric: TrendOut.shape.metric, ...TrendSegment.shape }),
+    z.object({ metric: TrendOut.shape.metric, window: TrendSegment.shape.label, avg: z.number().nullable(), min: z.number().nullable(), max: z.number().nullable(), delta_pct: z.number().nullable(), unit: z.string().nullable() }),
+    z.null(),
+  ])),
+});
+
+export const WeeklyPlanOut = z.object({
+  experimental: z.literal(true),
+  date: z.iso.date(), title: z.string().nullable(), days_left: z.string().nullable(),
+  accomplished_pct: z.number().nullable(),
+  goals: z.array(z.object({
+    id: z.string().nullable(), title: z.string().nullable(),
+    progress: z.object({ display: z.string().nullable(), current: z.number().nullable(), target: z.number().nullable(), percent: z.number().nullable() }).nullable(),
+  })),
+});
+
+export const LiftOverviewOut = z.object({
+  workouts: WorkoutListOut,
+  detailed_aggregate_available_via: z.literal("whoop_lift_history"),
+});
+
+export const PreferencesOut = z.object({
+  journal_enabled: z.boolean().nullable().optional(),
+  notifications: z.array(z.object({ namespace: z.string().nullable(), title: z.string().nullable(), enabled: z.boolean().nullable() })).optional(),
+});

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -4,6 +4,7 @@ import type { WhoopClient } from "../whoop/client.js";
 // Snapshots
 import { registerToday } from "./v2/today.js";
 import { registerDay } from "./v2/day.js";
+import { registerDailyBrief } from "./v2/daily_brief.js";
 import { registerProfile } from "./v2/profile.js";
 import { registerCalendar } from "./v2/calendar.js";
 // Deep dives
@@ -13,6 +14,8 @@ import { registerSleepEdit } from "./v2/sleep_edit.js";
 import { registerStrain } from "./v2/strain.js";
 // Trends + compare
 import { registerTrend } from "./v2/trend.js";
+import { registerTrendPack } from "./v2/trend_pack.js";
+import { registerWeeklyPlan } from "./v2/weekly_plan.js";
 import { registerCompare } from "./v2/compare.js";
 // Stress + sleep_need
 import { registerStress } from "./v2/stress.js";
@@ -21,6 +24,7 @@ import { registerSleepNeed } from "./v2/sleep_need.js";
 import { registerLiveHr } from "./v2/live_hr.js";
 import { registerLiveState } from "./v2/live_state.js";
 import { registerLiveStress } from "./v2/live_stress.js";
+import { registerActivityNow } from "./v2/activity_now.js";
 // Activities
 import { registerWorkouts } from "./v2/workouts.js";
 import { registerWorkout } from "./v2/workout.js";
@@ -32,6 +36,7 @@ import { registerLiftPrs } from "./v2/lift_prs.js";
 import { registerLiftExercise } from "./v2/lift_exercise.js";
 import { registerLiftProgression } from "./v2/lift_progression.js";
 import { registerLiftHistory } from "./v2/lift_history.js";
+import { registerLiftOverview } from "./v2/lift_overview.js";
 import { registerLiftLibrary } from "./v2/lift_library.js";
 import { registerLiftCatalog } from "./v2/lift_catalog.js";
 // Strength writes
@@ -62,6 +67,7 @@ import { registerHrZones } from "./v2/hr_zones.js";
 import { registerHrZonesSet } from "./v2/hr_zones_set.js";
 import { registerProfileUpdate } from "./v2/profile_update.js";
 import { registerHiddenMetric } from "./v2/hidden_metric.js";
+import { registerPreferences } from "./v2/preferences.js";
 // Escape
 import { registerRaw } from "./v2/raw.js";
 import { registerEndpoints } from "./v2/endpoints.js";
@@ -70,18 +76,22 @@ export function registerTools(server: McpServer, client: WhoopClient): void {
   // Reads (32)
   registerToday(server, client);
   registerDay(server, client);
+  registerDailyBrief(server, client);
   registerProfile(server, client);
   registerCalendar(server, client);
   registerRecovery(server, client);
   registerSleep(server, client);
   registerStrain(server, client);
   registerTrend(server, client);
+  registerTrendPack(server, client);
+  registerWeeklyPlan(server, client);
   registerCompare(server, client);
   registerStress(server, client);
   registerSleepNeed(server, client);
   registerLiveHr(server, client);
   registerLiveState(server, client);
   registerLiveStress(server, client);
+  registerActivityNow(server, client);
   registerWorkouts(server, client);
   registerWorkout(server, client);
   registerSportsCatalog(server, client);
@@ -89,6 +99,7 @@ export function registerTools(server: McpServer, client: WhoopClient): void {
   registerLiftExercise(server, client);
   registerLiftProgression(server, client);
   registerLiftHistory(server, client);
+  registerLiftOverview(server, client);
   registerLiftLibrary(server, client);
   registerLiftCatalog(server, client);
   registerJournal(server, client);
@@ -100,6 +111,7 @@ export function registerTools(server: McpServer, client: WhoopClient): void {
   registerLeaderboard(server, client);
   registerCommunities(server, client);
   registerHrZones(server, client);
+  registerPreferences(server, client);
   // Writes (15: 14 + coach_ask)
   registerActivityCreate(server, client);
   registerActivityDelete(server, client);

--- a/src/tools/v2/activity_now.ts
+++ b/src/tools/v2/activity_now.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { projectLiveHr } from "../../projections/live_hr.js";
+import { projectLiveState } from "../../projections/live_state.js";
+import { projectLiveStress } from "../../projections/live_stress.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { todayIso } from "../../lib/dates.js";
+
+const FIELDS = ["state", "heart_rate", "stress"] as const;
+
+function liveFreshness(sourceUpdatedAt: string | null): {
+  fetched_at: string;
+  source_updated_at: string | null;
+  source_age_ms: number | null;
+  completed_cache: "bypassed";
+} {
+  const fetchedAt = new Date();
+  const sourceMs = sourceUpdatedAt ? Date.parse(sourceUpdatedAt) : NaN;
+  return {
+    fetched_at: fetchedAt.toISOString(),
+    source_updated_at: sourceUpdatedAt,
+    source_age_ms: Number.isFinite(sourceMs) ? Math.max(0, fetchedAt.getTime() - sourceMs) : null,
+    completed_cache: "bypassed",
+  };
+}
+
+export function registerActivityNow(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_activity_now",
+    "Fresh live activity snapshot. Select state, heart_rate, and/or stress; no completed live value is cached.",
+    { include: z.array(z.enum(FIELDS)).min(1).refine((v) => new Set(v).size === v.length, "include must not contain duplicates").default(["state"]) },
+    async ({ include }) => {
+      const date = todayIso();
+      const [state, heartRate, stress] = await Promise.all([
+        include.includes("state") ? client.get("/activities-service/v1/user-state").then(projectLiveState) : Promise.resolve(null),
+        include.includes("heart_rate") ? client.get("/health-tab-bff/v1/health-tab").then(projectLiveHr) : Promise.resolve(null),
+        include.includes("stress") ? client.get(`/health-service/v2/stress-bff/${date}`).then(projectLiveStress) : Promise.resolve(null),
+      ]);
+      return { content: [{ type: "text", text: jsonOut({
+        state: state ? { ...state, freshness: liveFreshness(state.latest_metrics_at) } : null,
+        heart_rate: heartRate ? { ...heartRate, freshness: liveFreshness(heartRate.last_updated_at) } : null,
+        stress: stress ? { ...stress, freshness: liveFreshness(stress.last_updated_at) } : null,
+      }) }] };
+    },
+  );
+}

--- a/src/tools/v2/activity_now.ts
+++ b/src/tools/v2/activity_now.ts
@@ -6,6 +6,8 @@ import { projectLiveState } from "../../projections/live_state.js";
 import { projectLiveStress } from "../../projections/live_stress.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
+import { ActivityNowOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 const FIELDS = ["state", "heart_rate", "stress"] as const;
 
@@ -35,13 +37,19 @@ export function registerActivityNow(server: McpServer, client: WhoopClient): voi
       const [state, heartRate, stress] = await Promise.all([
         include.includes("state") ? client.get("/activities-service/v1/user-state").then(projectLiveState) : Promise.resolve(null),
         include.includes("heart_rate") ? client.get("/health-tab-bff/v1/health-tab").then(projectLiveHr) : Promise.resolve(null),
-        include.includes("stress") ? client.get(`/health-service/v2/stress-bff/${date}`).then(projectLiveStress) : Promise.resolve(null),
+        include.includes("stress") ? client.get(`/health-service/v2/stress-bff/${date}`).then((raw) => projectLiveStress(raw, date)) : Promise.resolve(null),
       ]);
-      return { content: [{ type: "text", text: jsonOut({
+      const out = {
         state: state ? { ...state, freshness: liveFreshness(state.latest_metrics_at) } : null,
         heart_rate: heartRate ? { ...heartRate, freshness: liveFreshness(heartRate.last_updated_at) } : null,
         stress: stress ? { ...stress, freshness: liveFreshness(stress.last_updated_at) } : null,
-      }) }] };
+      };
+      try {
+        return { content: [{ type: "text", text: jsonOut(ActivityNowOut.parse(out)) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_activity_now", error);
+        throw error;
+      }
     },
   );
 }

--- a/src/tools/v2/daily_brief.ts
+++ b/src/tools/v2/daily_brief.ts
@@ -6,6 +6,8 @@ import { projectStrain } from "../../projections/strain.js";
 import { projectSleepNeed } from "../../projections/sleep_need.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
+import { DailyBriefOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 const SECTIONS = ["recovery", "sleep", "strain", "sleep_plan", "activity"] as const;
 
@@ -48,7 +50,12 @@ export function registerDailyBrief(server: McpServer, client: WhoopClient): void
       if (sections.includes("activity") && core) out.activity = core.current_state;
       if (sections.includes("strain")) out.strain = strain;
       if (sections.includes("sleep_plan")) out.sleep_plan = sleepPlan;
-      return { content: [{ type: "text", text: jsonOut(out) }] };
+      try {
+        return { content: [{ type: "text", text: jsonOut(DailyBriefOut.parse(out)) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_daily_brief", error);
+        throw error;
+      }
     },
   );
 }

--- a/src/tools/v2/daily_brief.ts
+++ b/src/tools/v2/daily_brief.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { projectToday } from "../../projections/today.js";
+import { projectStrain } from "../../projections/strain.js";
+import { projectSleepNeed } from "../../projections/sleep_need.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { todayIso } from "../../lib/dates.js";
+
+const SECTIONS = ["recovery", "sleep", "strain", "sleep_plan", "activity"] as const;
+
+/** Compact, intent-oriented daily context so a model need not orchestrate 3–5 tools. */
+export function registerDailyBrief(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_daily_brief",
+    "Compact daily context. Request only the recovery, sleep, strain, sleep_plan, and activity sections needed; avoids heavy timelines and shares source reads.",
+    {
+      date: z.iso.date().optional().describe("Defaults to today. sleep_plan and activity are available only for today."),
+      sections: z.array(z.enum(SECTIONS)).min(1).refine((v) => new Set(v).size === v.length, "sections must not contain duplicates").default(["recovery", "sleep", "strain", "sleep_plan"]),
+      detail: z.enum(["compact", "standard"]).default("compact"),
+    },
+    async ({ date, sections, detail }) => {
+      const d = date ?? todayIso();
+      const isToday = d === todayIso();
+      if (!isToday && (sections.includes("sleep_plan") || sections.includes("activity"))) {
+        return { content: [{ type: "text", text: jsonOut({ error: "sleep_plan and activity are only available for today." }) }], isError: true };
+      }
+      const coreNeeded = sections.some((section) => ["recovery", "sleep", "activity"].includes(section));
+      const [core, strain, sleepPlan] = await Promise.all([
+        coreNeeded
+          ? Promise.all([
+              client.get("/home-service/v1/home", { date: d }),
+              client.get("/developer/v2/activity/sleep", { limit: "5" }).catch(() => null),
+              client.get("/home-service/v1/deep-dive/recovery", { date: d }).catch(() => null),
+              sections.includes("activity") ? client.get("/activities-service/v1/user-state").catch(() => null) : Promise.resolve(null),
+            ]).then(([home, sleep, recovery, state]) => projectToday({ home, sleep, recovery, state, date: d }))
+          : Promise.resolve(null),
+        sections.includes("strain") ? client.get("/home-service/v1/deep-dive/strain", { date: d }).then((raw) => projectStrain(raw, d)) : Promise.resolve(null),
+        sections.includes("sleep_plan") ? client.get("/coaching-service/v2/sleepneed").then(projectSleepNeed) : Promise.resolve(null),
+      ]);
+      const out: Record<string, unknown> = { date: d };
+      if (sections.includes("recovery") && core) out.recovery = core.recovery;
+      if (sections.includes("sleep") && core) {
+        out.sleep = detail === "compact"
+          ? { performance_pct: core.sleep.performance_pct, total_sleep_ms: core.sleep.total_sleep_ms, efficiency_pct: core.sleep.efficiency_pct, started_at: core.sleep.started_at, ended_at: core.sleep.ended_at }
+          : core.sleep;
+      }
+      if (sections.includes("activity") && core) out.activity = core.current_state;
+      if (sections.includes("strain")) out.strain = strain;
+      if (sections.includes("sleep_plan")) out.sleep_plan = sleepPlan;
+      return { content: [{ type: "text", text: jsonOut(out) }] };
+    },
+  );
+}

--- a/src/tools/v2/lift_overview.ts
+++ b/src/tools/v2/lift_overview.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { projectWorkoutsList } from "../../projections/workouts.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { rangeFromDays } from "../../lib/dates.js";
+
+export function registerLiftOverview(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_lift_overview",
+    "Compact recent strength-workout overview. Uses one upstream list request; use whoop_lift_history only when per-exercise aggregates are needed.",
+    { limit: z.number().int().min(1).max(20).default(5), end_date: z.iso.date().optional() },
+    async ({ limit, end_date }) => {
+      const end = end_date ? new Date(`${end_date}T23:59:59.999Z`) : new Date();
+      const window = rangeFromDays(60, end);
+      const raw = await client.get("/developer/v2/activity/workout", { start: window.start, end: window.end, limit: 25 });
+      const all = projectWorkoutsList(raw, undefined, 25);
+      const workouts = all.filter((workout) => /weight|strength|powerlift/i.test(workout.sport_name ?? "")).slice(0, limit);
+      return { content: [{ type: "text", text: jsonOut({ workouts, detailed_aggregate_available_via: "whoop_lift_history" }) }] };
+    },
+  );
+}

--- a/src/tools/v2/lift_overview.ts
+++ b/src/tools/v2/lift_overview.ts
@@ -4,6 +4,8 @@ import type { WhoopClient } from "../../whoop/client.js";
 import { projectWorkoutsList } from "../../projections/workouts.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { rangeFromDays } from "../../lib/dates.js";
+import { LiftOverviewOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 export function registerLiftOverview(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -16,7 +18,12 @@ export function registerLiftOverview(server: McpServer, client: WhoopClient): vo
       const raw = await client.get("/developer/v2/activity/workout", { start: window.start, end: window.end, limit: 25 });
       const all = projectWorkoutsList(raw, undefined, 25);
       const workouts = all.filter((workout) => /weight|strength|powerlift/i.test(workout.sport_name ?? "")).slice(0, limit);
-      return { content: [{ type: "text", text: jsonOut({ workouts, detailed_aggregate_available_via: "whoop_lift_history" }) }] };
+      try {
+        return { content: [{ type: "text", text: jsonOut(LiftOverviewOut.parse({ workouts, detailed_aggregate_available_via: "whoop_lift_history" })) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_lift_overview", error);
+        throw error;
+      }
     },
   );
 }

--- a/src/tools/v2/preferences.ts
+++ b/src/tools/v2/preferences.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { asArray, asBool, asString, isObject } from "../../lib/walk.js";
+
+/** Compact, read-only account preferences that otherwise require raw API calls. */
+export function registerPreferences(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_preferences",
+    "Read compact account preferences: journal enabled state and/or notification switches. Read-only; omit sections you do not need.",
+    {
+      include: z.array(z.enum(["journal", "notifications"])).min(1).max(2).default(["journal", "notifications"]),
+    },
+    async ({ include }) => {
+      const wantsJournal = include.includes("journal");
+      const wantsNotifications = include.includes("notifications");
+      const [journal, notifications] = await Promise.all([
+        wantsJournal ? client.get("/journal-service/v1/journals/preferences") : Promise.resolve(null),
+        wantsNotifications ? client.get("/notification-service/v1/notifications/user-settings/bff") : Promise.resolve(null),
+      ]);
+      const journalRoot = isObject(journal) ? journal : {};
+      const notificationRoot = isObject(notifications) ? notifications : {};
+      const settings = asArray(notificationRoot.settings).flatMap((setting) => {
+        if (!isObject(setting)) return [];
+        return [{
+          namespace: asString(setting.push_namespace),
+          title: asString(setting.title),
+          enabled: asBool(setting.active),
+        }];
+      });
+      return { content: [{ type: "text", text: jsonOut({
+        ...(wantsJournal ? { journal_enabled: asBool(journalRoot.journal_enabled) } : {}),
+        ...(wantsNotifications ? { notifications: settings } : {}),
+      }) }] };
+    },
+  );
+}

--- a/src/tools/v2/preferences.ts
+++ b/src/tools/v2/preferences.ts
@@ -3,6 +3,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { WhoopClient } from "../../whoop/client.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { asArray, asBool, asString, isObject } from "../../lib/walk.js";
+import { PreferencesOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 /** Compact, read-only account preferences that otherwise require raw API calls. */
 export function registerPreferences(server: McpServer, client: WhoopClient): void {
@@ -29,10 +31,16 @@ export function registerPreferences(server: McpServer, client: WhoopClient): voi
           enabled: asBool(setting.active),
         }];
       });
-      return { content: [{ type: "text", text: jsonOut({
+      const out = {
         ...(wantsJournal ? { journal_enabled: asBool(journalRoot.journal_enabled) } : {}),
         ...(wantsNotifications ? { notifications: settings } : {}),
-      }) }] };
+      };
+      try {
+        return { content: [{ type: "text", text: jsonOut(PreferencesOut.parse(out)) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_preferences", error);
+        throw error;
+      }
     },
   );
 }

--- a/src/tools/v2/trend_pack.ts
+++ b/src/tools/v2/trend_pack.ts
@@ -5,6 +5,8 @@ import { METRICS } from "../../schemas/trend.js";
 import { projectTrend } from "../../projections/trend.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
+import { TrendPackOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 export function registerTrendPack(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -31,7 +33,12 @@ export function registerTrendPack(server: McpServer, client: WhoopClient): void 
           unit: segment.unit,
         });
       }));
-      return { content: [{ type: "text", text: jsonOut({ end_date: d, window, trends }) }] };
+      try {
+        return { content: [{ type: "text", text: jsonOut(TrendPackOut.parse({ end_date: d, window, trends })) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_trend_pack", error);
+        throw error;
+      }
     },
   );
 }

--- a/src/tools/v2/trend_pack.ts
+++ b/src/tools/v2/trend_pack.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { METRICS } from "../../schemas/trend.js";
+import { projectTrend } from "../../projections/trend.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { todayIso } from "../../lib/dates.js";
+
+export function registerTrendPack(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_trend_pack",
+    "Compact trend summaries for up to five requested metrics. Per-day points are omitted unless include_points is true.",
+    {
+      metrics: z.array(z.enum(METRICS)).min(1).max(5).refine((v) => new Set(v).size === v.length, "metrics must not contain duplicates"),
+      end_date: z.iso.date().optional(),
+      window: z.enum(["week", "month", "six_month", "year"]).default("month"),
+      include_points: z.boolean().default(false),
+    },
+    async ({ metrics, end_date, window, include_points }) => {
+      const d = end_date ?? todayIso();
+      const trends = await Promise.all(metrics.map(async (metric) => {
+        const raw = await client.get(`/progression-service/v3/trends/${metric}`, { endDate: d });
+        const segment = projectTrend(raw, metric, d).segments.find((item) => item.label === window) ?? null;
+        return segment && (include_points ? { metric, ...segment } : {
+          metric,
+          window: segment.label,
+          avg: segment.avg,
+          min: segment.min,
+          max: segment.max,
+          delta_pct: segment.delta_pct,
+          unit: segment.unit,
+        });
+      }));
+      return { content: [{ type: "text", text: jsonOut({ end_date: d, window, trends }) }] };
+    },
+  );
+}

--- a/src/tools/v2/weekly_plan.ts
+++ b/src/tools/v2/weekly_plan.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../whoop/client.js";
+import { jsonOut } from "../../whoop/json_out.js";
+import { todayIso } from "../../lib/dates.js";
+import { asArray, asNumber, asString, isObject } from "../../lib/walk.js";
+
+/** A compact projection of Whoop's weekly-plan home tile. */
+export function registerWeeklyPlan(server: McpServer, client: WhoopClient): void {
+  server.tool(
+    "whoop_weekly_plan",
+    "Weekly-plan progress in a compact, model-friendly form: overall completion plus each active sleep, steps, or strength goal.",
+    { date: z.iso.date().optional().describe("Any date in the target week. Defaults to today.") },
+    async ({ date }) => {
+      const d = date ?? todayIso();
+      const raw = await client.get(`/progression-service/v2/weekly-plan/home-tile/${d}`);
+      const root = isObject(raw) ? raw : {};
+      const tile = isObject(root.tile) ? root.tile : {};
+      const content = isObject(tile.content) ? tile.content : {};
+      const progress = isObject(content.progress_bar) ? content.progress_bar : {};
+      const goals = asArray(content.items).flatMap((item) => {
+        if (!isObject(item)) return [];
+        const indicator = isObject(item.circular_progress_indicator) ? item.circular_progress_indicator : {};
+        const steps = isObject(indicator.current_progress_steps) ? indicator.current_progress_steps : null;
+        const percentage = isObject(indicator.current_progress_percentage) ? indicator.current_progress_percentage : null;
+        return [{
+          id: asString(item.id),
+          title: asString(item.title),
+          progress: steps
+            ? { display: asString(steps.text_display), current: asNumber(steps.current_step), target: asNumber(steps.total_steps), percent: null }
+            : percentage
+              ? { display: asString(percentage.text_display), current: null, target: null, percent: asNumber(percentage.percentage) }
+              : null,
+        }];
+      });
+      return { content: [{ type: "text", text: jsonOut({
+        date: d,
+        title: asString(content.title),
+        days_left: asString(content.days_left_display),
+        accomplished_pct: asNumber(progress.percent_value),
+        goals,
+      }) }] };
+    },
+  );
+}

--- a/src/tools/v2/weekly_plan.ts
+++ b/src/tools/v2/weekly_plan.ts
@@ -4,12 +4,14 @@ import type { WhoopClient } from "../../whoop/client.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
 import { asArray, asNumber, asString, isObject } from "../../lib/walk.js";
+import { WeeklyPlanOut } from "../../schemas/compact.js";
+import { WhoopProjectionError } from "../../whoop/errors.js";
 
 /** A compact projection of Whoop's weekly-plan home tile. */
 export function registerWeeklyPlan(server: McpServer, client: WhoopClient): void {
   server.tool(
     "whoop_weekly_plan",
-    "Weekly-plan progress in a compact, model-friendly form: overall completion plus each active sleep, steps, or strength goal.",
+    "EXPERIMENTAL: Weekly-plan progress in a compact form. Its upstream endpoint has not yet been verified against a live account.",
     { date: z.iso.date().optional().describe("Any date in the target week. Defaults to today.") },
     async ({ date }) => {
       const d = date ?? todayIso();
@@ -33,13 +35,20 @@ export function registerWeeklyPlan(server: McpServer, client: WhoopClient): void
               : null,
         }];
       });
-      return { content: [{ type: "text", text: jsonOut({
+      const out = {
+        experimental: true as const,
         date: d,
         title: asString(content.title),
         days_left: asString(content.days_left_display),
         accomplished_pct: asNumber(progress.percent_value),
         goals,
-      }) }] };
+      };
+      try {
+        return { content: [{ type: "text", text: jsonOut(WeeklyPlanOut.parse(out)) }] };
+      } catch (error) {
+        if (error instanceof z.ZodError) throw new WhoopProjectionError("whoop_weekly_plan", error);
+        throw error;
+      }
     },
   );
 }

--- a/tests/tools/compact_helpers.test.ts
+++ b/tests/tools/compact_helpers.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../src/whoop/client.js";
+import { registerDailyBrief } from "../../src/tools/v2/daily_brief.js";
+import { registerActivityNow } from "../../src/tools/v2/activity_now.js";
+import { registerWeeklyPlan } from "../../src/tools/v2/weekly_plan.js";
+import { registerPreferences } from "../../src/tools/v2/preferences.js";
+
+const closers: Array<() => Promise<void>> = [];
+afterEach(async () => { await Promise.all(closers.splice(0).map((close) => close())); });
+
+async function connect(register: (server: McpServer) => void): Promise<Client> {
+  const server = new McpServer({ name: "test-server", version: "1" });
+  register(server);
+  const client = new Client({ name: "test-client", version: "1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  closers.push(async () => { await client.close(); await server.close(); });
+  return client;
+}
+
+describe("compact helper tools", () => {
+  it("daily brief fetches only requested sections", async () => {
+    const get = vi.fn().mockResolvedValue({});
+    const client = await connect((server) => registerDailyBrief(server, { get } as unknown as WhoopClient));
+    const result = await client.callTool({ name: "whoop_daily_brief", arguments: { sections: ["strain"] } });
+    expect(result.isError).not.toBe(true);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith("/home-service/v1/deep-dive/strain", expect.anything());
+  });
+
+  it("activity-now leaves unrequested live endpoints untouched", async () => {
+    const get = vi.fn().mockResolvedValue({ state: "idle" });
+    const client = await connect((server) => registerActivityNow(server, { get } as unknown as WhoopClient));
+    const result = await client.callTool({ name: "whoop_activity_now", arguments: { include: ["state"] } });
+    expect(result.isError).not.toBe(true);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith("/activities-service/v1/user-state");
+    const output = JSON.parse((result.content as Array<{ text: string }>)[0]!.text);
+    expect(output.state.freshness.completed_cache).toBe("bypassed");
+    expect(output.state.freshness.fetched_at).toBeTruthy();
+  });
+
+  it("projects weekly-plan goals without exposing the raw tile", async () => {
+    const get = vi.fn().mockResolvedValue({ tile: { content: {
+      title: "CUSTOM PLAN", days_left_display: "7 days left", progress_bar: { percent_value: 5 },
+      items: [{ id: "STEPS", title: "1,600+ Steps", circular_progress_indicator: { current_progress_steps: { text_display: "1/7", current_step: 1, total_steps: 7 } } }],
+    } } });
+    const client = await connect((server) => registerWeeklyPlan(server, { get } as unknown as WhoopClient));
+    const result = await client.callTool({ name: "whoop_weekly_plan", arguments: { date: "2026-08-24" } });
+    const output = JSON.stringify(result.content);
+    expect(result.isError).not.toBe(true);
+    expect(output).toContain("CUSTOM PLAN");
+    expect(output).toContain("1/7");
+    expect(get).toHaveBeenCalledWith("/progression-service/v2/weekly-plan/home-tile/2026-08-24");
+  });
+
+  it("preferences fetches only the explicitly selected preference category", async () => {
+    const get = vi.fn().mockResolvedValue({ journal_enabled: true });
+    const client = await connect((server) => registerPreferences(server, { get } as unknown as WhoopClient));
+    const result = await client.callTool({ name: "whoop_preferences", arguments: { include: ["journal"] } });
+    expect(result.isError).not.toBe(true);
+    expect(JSON.stringify(result.content)).toContain("journal_enabled");
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith("/journal-service/v1/journals/preferences");
+  });
+});


### PR DESCRIPTION
Adds six additive, low-call tools: daily brief, activity now, trend pack, weekly plan, lift overview, and preferences. Every output is validated through a dedicated Zod schema.

`whoop_weekly_plan` is explicitly experimental until its upstream response shape is confirmed by a captured live fixture.

Verification: `npx tsc --noEmit`; `npx vitest run tests/tools/compact_helpers.test.ts`.