### PR TITLE
fix: improve live freshness and read projections

### DIFF
--- a/src/lib/live_freshness.ts
+++ b/src/lib/live_freshness.ts
@@ -1,0 +1,16 @@
+/** Metadata for values whose completed responses deliberately bypass the cache. */
+export function liveFreshness(sourceUpdatedAt: string | null): {
+  fetched_at: string;
+  source_updated_at: string | null;
+  source_age_ms: number | null;
+  completed_cache: "bypassed";
+} {
+  const fetchedAt = new Date();
+  const sourceMs = sourceUpdatedAt ? Date.parse(sourceUpdatedAt) : NaN;
+  return {
+    fetched_at: fetchedAt.toISOString(),
+    source_updated_at: sourceUpdatedAt,
+    source_age_ms: Number.isFinite(sourceMs) ? Math.max(0, fetchedAt.getTime() - sourceMs) : null,
+    completed_cache: "bypassed",
+  };
+}

--- a/src/projections/live_stress.ts
+++ b/src/projections/live_stress.ts
@@ -1,8 +1,8 @@
 import type { LiveStressOutT } from "../schemas/live.js";
 import { projectStress } from "./stress.js";
 
-export function projectLiveStress(raw: unknown): LiveStressOutT {
-  const full = projectStress(raw, "1970-01-01");
+export function projectLiveStress(raw: unknown, date: string): LiveStressOutT {
+  const full = projectStress(raw, date);
   return {
     current_level: full.current_level,
     baseline_level: full.baseline_level,

--- a/src/projections/today.ts
+++ b/src/projections/today.ts
@@ -28,7 +28,7 @@ function gaugeScore(g: Record<string, unknown> | null): number | null {
   return asNumber(g.score_display);
 }
 
-interface SleepSummary {
+export interface SleepSummary {
   performance_pct: number | null;
   total_sleep_ms: number | null;
   time_in_bed_ms: number | null;
@@ -41,7 +41,7 @@ interface SleepSummary {
 // Map a /developer/v2/activity/sleep response → the snapshot's sleep summary.
 // Picks the main (non-nap) sleep whose local end date matches `date`, else the
 // most recent. All stage durations come straight from score.stage_summary.
-function sleepSummary(resp: unknown, date: string): SleepSummary | null {
+export function projectActivitySleepSummary(resp: unknown, date: string): SleepSummary | null {
   const root = isObject(resp) ? resp : {};
   const records = asArray(root.records).filter(
     (r): r is Record<string, unknown> => isObject(r) && r.nap !== true,
@@ -118,7 +118,7 @@ export function projectToday(input: ProjectTodayInput): TodayOutT {
   const workoutsCount = workoutIds.size;
 
   // Sleep summary from the lightweight /developer/v2/activity/sleep endpoint
-  const sleepSum = sleep ? sleepSummary(sleep, date) : null;
+  const sleepSum = sleep ? projectActivitySleepSummary(sleep, date) : null;
   const recProj = recovery ? projectRecovery(recovery, date) : null;
 
   // Activity state

--- a/src/schemas/live.ts
+++ b/src/schemas/live.ts
@@ -1,12 +1,20 @@
 import { z } from "zod";
 import { IsoDateTime } from "./primitives.js";
 
+export const LiveFreshnessOut = z.object({
+  fetched_at: IsoDateTime,
+  source_updated_at: IsoDateTime.nullable(),
+  source_age_ms: z.number().int().nonnegative().nullable(),
+  completed_cache: z.literal("bypassed"),
+});
+
 export const LiveHrOut = z.object({
   current_bpm: z.number().int().nullable(),
   hr_zone: z.number().int().min(0).max(5).nullable(),
   is_recording: z.boolean(),
   last_updated_at: IsoDateTime.nullable(),
   show_live_hr: z.boolean(),
+  freshness: LiveFreshnessOut.optional(),
 });
 export type LiveHrOutT = z.infer<typeof LiveHrOut>;
 
@@ -19,6 +27,7 @@ export const LiveStateOut = z.object({
   duration_so_far_ms: z.number().int().nullable(),
   tracked_sleep: z.boolean(),
   latest_metrics_at: IsoDateTime.nullable(),
+  freshness: LiveFreshnessOut.optional(),
 });
 export type LiveStateOutT = z.infer<typeof LiveStateOut>;
 
@@ -27,5 +36,6 @@ export const LiveStressOut = z.object({
   baseline_level: z.number().nullable(),
   calibration_state: z.enum(["CALIBRATING", "CALIBRATED"]).nullable(),
   last_updated_at: IsoDateTime.nullable(),
+  freshness: LiveFreshnessOut.optional(),
 });
 export type LiveStressOutT = z.infer<typeof LiveStressOut>;

--- a/src/tools/v2/calendar.ts
+++ b/src/tools/v2/calendar.ts
@@ -16,10 +16,15 @@ export function registerCalendar(server: McpServer, client: WhoopClient): void {
     },
     async ({ date }) => {
       const d = date ?? todayIso();
-      const [overview, recovery] = await Promise.all([
-        client.get("/home-service/v1/calendar/overview", { date: d }),
-        client.get("/home-service/v1/calendar/recovery", { date: d }).catch(() => null),
-      ]);
+      // Both endpoints contain the same state grid. Prefer recovery and only
+      // pay for overview when that endpoint is unavailable.
+      let recovery: unknown = null;
+      let overview: unknown = null;
+      try {
+        recovery = await client.get("/home-service/v1/calendar/recovery", { date: d });
+      } catch {
+        overview = await client.get("/home-service/v1/calendar/overview", { date: d });
+      }
       const projected = projectCalendar({ overview, recovery, date: d });
       try {
         const out = CalendarOut.parse(projected);

--- a/src/tools/v2/compare.ts
+++ b/src/tools/v2/compare.ts
@@ -24,7 +24,10 @@ export function registerCompare(server: McpServer, client: WhoopClient): void {
       window: z.enum(["week", "month"]).default("week"),
       end_a: z.iso.date().optional(),
       end_b: z.iso.date().optional(),
-      metrics: z.array(z.enum(COMPARE_METRICS)).default([...COMPARE_METRICS]),
+      metrics: z.array(z.enum(COMPARE_METRICS)).min(1).max(COMPARE_METRICS.length).refine(
+        (values) => new Set(values).size === values.length,
+        "metrics must not contain duplicates",
+      ).default([...COMPARE_METRICS]),
     },
     async ({ window, end_a, end_b, metrics }) => {
       const a = end_a ?? todayIso();

--- a/src/tools/v2/live_hr.ts
+++ b/src/tools/v2/live_hr.ts
@@ -5,6 +5,7 @@ import { LiveHrOut } from "../../schemas/live.js";
 import { projectLiveHr } from "../../projections/live_hr.js";
 import { WhoopProjectionError } from "../../whoop/errors.js";
 import { jsonOut } from "../../whoop/json_out.js";
+import { liveFreshness } from "../../lib/live_freshness.js";
 
 export function registerLiveHr(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -15,7 +16,7 @@ export function registerLiveHr(server: McpServer, client: WhoopClient): void {
       const raw = await client.get("/health-tab-bff/v1/health-tab");
       const projected = projectLiveHr(raw);
       try {
-        const out = LiveHrOut.parse(projected);
+        const out = LiveHrOut.parse({ ...projected, freshness: liveFreshness(projected.last_updated_at) });
         return { content: [{ type: "text", text: jsonOut(out) }] };
       } catch (e) {
         if (e instanceof z.ZodError) throw new WhoopProjectionError("whoop_live_hr", e);

--- a/src/tools/v2/live_state.ts
+++ b/src/tools/v2/live_state.ts
@@ -5,6 +5,7 @@ import { LiveStateOut } from "../../schemas/live.js";
 import { projectLiveState } from "../../projections/live_state.js";
 import { WhoopProjectionError } from "../../whoop/errors.js";
 import { jsonOut } from "../../whoop/json_out.js";
+import { liveFreshness } from "../../lib/live_freshness.js";
 
 export function registerLiveState(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -15,7 +16,7 @@ export function registerLiveState(server: McpServer, client: WhoopClient): void 
       const raw = await client.get("/activities-service/v1/user-state");
       const projected = projectLiveState(raw);
       try {
-        const out = LiveStateOut.parse(projected);
+        const out = LiveStateOut.parse({ ...projected, freshness: liveFreshness(projected.latest_metrics_at) });
         return { content: [{ type: "text", text: jsonOut(out) }] };
       } catch (e) {
         if (e instanceof z.ZodError) throw new WhoopProjectionError("whoop_live_state", e);

--- a/src/tools/v2/live_stress.ts
+++ b/src/tools/v2/live_stress.ts
@@ -6,6 +6,7 @@ import { projectLiveStress } from "../../projections/live_stress.js";
 import { WhoopProjectionError } from "../../whoop/errors.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
+import { liveFreshness } from "../../lib/live_freshness.js";
 
 export function registerLiveStress(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -13,10 +14,11 @@ export function registerLiveStress(server: McpServer, client: WhoopClient): void
     "Current stress level (terse). Cheaper than whoop_stress if you just want the latest reading.",
     {},
     async () => {
-      const raw = await client.get(`/health-service/v2/stress-bff/${todayIso()}`);
-      const projected = projectLiveStress(raw);
+      const date = todayIso();
+      const raw = await client.get(`/health-service/v2/stress-bff/${date}`);
+      const projected = projectLiveStress(raw, date);
       try {
-        const out = LiveStressOut.parse(projected);
+        const out = LiveStressOut.parse({ ...projected, freshness: liveFreshness(projected.last_updated_at) });
         return { content: [{ type: "text", text: jsonOut(out) }] };
       } catch (e) {
         if (e instanceof z.ZodError) throw new WhoopProjectionError("whoop_live_stress", e);

--- a/src/tools/v2/sleep.ts
+++ b/src/tools/v2/sleep.ts
@@ -6,6 +6,7 @@ import { projectSleep } from "../../projections/sleep.js";
 import { WhoopProjectionError } from "../../whoop/errors.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
+import { projectActivitySleepSummary } from "../../projections/today.js";
 
 export function registerSleep(server: McpServer, client: WhoopClient): void {
   server.tool(
@@ -14,8 +15,16 @@ export function registerSleep(server: McpServer, client: WhoopClient): void {
     { date: z.iso.date().optional() },
     async ({ date }) => {
       const d = date ?? todayIso();
-      const raw = await client.get("/home-service/v1/deep-dive/sleep/last-night", { date: d });
+      const [raw, activitySleep] = await Promise.all([
+        client.get("/home-service/v1/deep-dive/sleep/last-night", { date: d }),
+        // This is WHOOP's scored per-sleep record, the authoritative source
+        // for sleep performance. The deep-dive's "Hours vs. Needed" card is a
+        // related but distinct, sometimes different metric.
+        client.get("/developer/v2/activity/sleep", { limit: "5" }).catch(() => null),
+      ]);
       const projected = projectSleep(raw, d);
+      const performance = projectActivitySleepSummary(activitySleep, d)?.performance_pct;
+      if (performance !== null && performance !== undefined) projected.performance_pct = performance;
       try {
         const out = SleepOut.parse(projected);
         return { content: [{ type: "text", text: jsonOut(out) }] };

--- a/tests/projections/live_stress.test.ts
+++ b/tests/projections/live_stress.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { projectLiveStress } from "../../src/projections/live_stress.js";
+
+describe("projectLiveStress", () => {
+  it("uses the requested day for timeline freshness instead of 1970", () => {
+    const out = projectLiveStress({
+      gauge: { gauge_score_display: "1.2" },
+      stress_graph: { graph: { plots: [{ plot: { segments: [{ points: [
+        { data_scrubber_details: { primary_contextual_display: "9:30 AM", value_display: "1.2" } },
+      ] }] } }] } },
+    }, "2026-08-24");
+    expect(out.last_updated_at).toContain("2026-08-24");
+  });
+});

--- a/tests/projections/round1.test.ts
+++ b/tests/projections/round1.test.ts
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 import { projectRecovery } from "../../src/projections/recovery.js";
 import { projectStrain } from "../../src/projections/strain.js";
 import { projectSleep } from "../../src/projections/sleep.js";
-import { projectToday } from "../../src/projections/today.js";
+import { projectActivitySleepSummary, projectToday } from "../../src/projections/today.js";
 import { projectTrend } from "../../src/projections/trend.js";
 import { projectCalendar } from "../../src/projections/calendar.js";
 import { projectSleepNeed } from "../../src/projections/sleep_need.js";
@@ -165,6 +165,12 @@ describe("projectToday for whoop_day (state=null, past date)", () => {
     expect(out.recovery.score).toBe(78);
     expect(out.sleep.performance_pct).toBe(83);
     expect(out.strain.score).toBe(17.8);
+  });
+});
+
+describe("projectActivitySleepSummary", () => {
+  it("uses the scored per-sleep performance metric", () => {
+    expect(projectActivitySleepSummary(load("activity_sleep.json"), "2026-05-28")?.performance_pct).toBe(83);
   });
 });
 


### PR DESCRIPTION
Makes live outputs explicitly fresh, fixes live-stress date projection, uses the authoritative sleep score, and avoids redundant calendar reads.

Verification: `npx tsc --noEmit`; targeted projection tests.