### PR TITLE
feat: expose deployment build identity in health checks

### DIFF
--- a/src/build_info.ts
+++ b/src/build_info.ts
@@ -1,0 +1,4 @@
+// Set TOTEM_BUILD_ID in CI/deployment (normally the immutable git SHA or image
+// digest). The value is intentionally non-secret and lets /health prove which
+// artifact is serving a connector after deployment.
+export const BUILD_ID = process.env.TOTEM_BUILD_ID || process.env.FLY_IMAGE_REF || "dev";

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -24,6 +24,7 @@ import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middlew
 import type { WhoopClient } from "./whoop/client.js";
 import { registerTools } from "./tools/register.js";
 import { WhoopOAuthProvider, renderConsentForm, setConsentSecurityHeaders } from "./whoop/oauth_provider.js";
+import { BUILD_ID } from "./build_info.js";
 
 export interface HttpServerOptions {
   /** Bearer token clients must present + JWT signing secret. Required, ≥16 chars. */
@@ -136,7 +137,8 @@ export async function startHttpServer(client: WhoopClient, opts: HttpServerOptio
 
   // Health probe — no auth. Container hosts (Fly/Docker HEALTHCHECK) hit this.
   app.get("/health", (_req, res) => {
-    res.json({ status: "ok" });
+    res.setHeader("x-totem-build", BUILD_ID);
+    res.json({ status: "ok", build: BUILD_ID });
   });
 
   // OAuth 2.1 authorization-server endpoints: /.well-known/oauth-authorization-server,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { registerTools } from "./tools/register.js";
 import { startTimezoneAutoDetect } from "./whoop/init_timezone.js";
 import { resolveInstallationId } from "./whoop/installation.js";
 import { versionStaleWarning } from "./whoop/device.js";
+import { BUILD_ID } from "./build_info.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ENV_PATH = resolve(__dirname, "../.env");
@@ -38,6 +39,7 @@ function chooseStore(): TokenStore {
 }
 
 async function main(): Promise<void> {
+  console.error(`[totem] build=${BUILD_ID}`);
   // Generate + persist a stable per-install identifier before any request goes
   // out, so every data request carries the same `x-whoop-installation-identifier`
   // the iOS app sends. Persisted to the env file like the tokens.


### PR DESCRIPTION
Adds a non-secret build identifier to startup logs and the `/health` response/header for deployment verification.

Verification: `npx tsc --noEmit`; `npx vitest run tests/whoop/http_auth.test.ts`.