### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project. Format roughly follows [Keep a Changelog](h
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-08-28
+
 A reliability + efficiency pass, landed as a series of focused PRs (#15–#22, #24) reviewed individually. Tool count 49 → **55**; test suite → **278**.
 
 ### Added

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -34,5 +34,5 @@
   "/>
 
   <!-- Stats: horizontally centered to viewBox midpoint -->
-  <text class="stats" x="410" y="245" text-anchor="middle" xml:space="preserve">v1.4.4<tspan class="sep">  ·  </tspan>55 tools<tspan class="sep">  ·  </tspan>47 microservices<tspan class="sep">  ·  </tspan>311 endpoints</text>
+  <text class="stats" x="410" y="245" text-anchor="middle" xml:space="preserve">v1.5.0<tspan class="sep">  ·  </tspan>55 tools<tspan class="sep">  ·  </tspan>47 microservices<tspan class="sep">  ·  </tspan>311 endpoints</text>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thebriangao/totem",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "mcpName": "io.github.thebriangao/totem",
   "description": "Totem — talk to your wearables with AI over MCP. Today: full Whoop access via its private iOS API (55 tools, read + write, zod-validated outputs, auto-refresh Cognito auth). Fitbit, Apple Watch, and Garmin adapters in progress.",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/thebriangao/totem",
     "source": "github"
   },
-  "version": "1.4.4",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@thebriangao/totem",
-      "version": "1.4.4",
+      "version": "1.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -91,7 +91,7 @@ export async function startHttpServer(client: WhoopClient, opts: HttpServerOptio
       }
     }
     const newId = randomUUID();
-    const newServer = new McpServer({ name: "totem", version: "1.4.4" });
+    const newServer = new McpServer({ name: "totem", version: "1.5.0" });
     registerTools(newServer, client);
     const newTransport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => newId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,7 +76,7 @@ async function main(): Promise<void> {
   }
 
   // stdio (default — local Claude Desktop / Claude Code)
-  const server = new McpServer({ name: "totem", version: "1.4.4" });
+  const server = new McpServer({ name: "totem", version: "1.5.0" });
   registerTools(server, client);
   await server.connect(new StdioServerTransport());
 }


### PR DESCRIPTION
Version bump to 1.5.0 across package.json, server.json, the McpServer identity, and the banner, plus the CHANGELOG [1.5.0] heading. Tag + GitHub release follow once this lands. tsc clean.