### PR TITLE
fix(journal): write entries the app can actually show

### DIFF
--- a/src/schemas/journal.ts
+++ b/src/schemas/journal.ts
@@ -72,6 +72,10 @@ export const JournalLogOut = withPreview(z.object({
   logged: z.literal(true),
   date: z.iso.date(),
   behaviors_count: z.number().int(),
+  // Answers already on the date that the write carried over untouched.
+  preserved_count: z.number().int(),
+  // The day was read back and the requested rows are answered server-side.
+  verified: z.literal(true),
 }));
 
 export const JournalAutopopOut = withPreview(z.object({

--- a/src/tools/v2/journal_log.ts
+++ b/src/tools/v2/journal_log.ts
@@ -6,26 +6,117 @@ import { preview } from "../../whoop/write_safety.js";
 import { jsonOut } from "../../whoop/json_out.js";
 import { todayIso } from "../../lib/dates.js";
 import { BEHAVIORS, BEHAVIORS_BY_ID, BEHAVIORS_BY_NAME } from "../../data/behaviors.js";
+import { isObject, asArray, asNumber, asString, asBool } from "../../lib/walk.js";
+
+// A journal row only renders in the Whoop app when `answered_yes` is true. A
+// tracker_input written without it lands server-side with `answered_yes: null`
+// — invisible in the app, yet the write returns 200. The bundled catalog marks
+// every behavior `magnitude: "bare"`, so gating the request on that field
+// rejected `answered_yes`, the magnitude and the time input for behaviors that
+// genuinely accept them (Sauna takes 1-300 minutes, Alcohol 1-20 drinks), and
+// the resulting entry was silently unreadable to the user.
+//
+// The live draft is the authority: each tracked behavior carries its real
+// `question_type` and `magnitude` spec. Validate against that when it is
+// available, default YES_NO behaviors to `true`, and confirm the write by
+// reading the day back instead of trusting the status code.
+
+export type LiveSpec = {
+  question_type: string | null;
+  magnitude: { type: string | null; units: string | null; minimum: number | null; maximum: number | null } | null;
+};
+
+export function specsFromDraft(raw: unknown): Map<number, LiveSpec> {
+  const specs = new Map<number, LiveSpec>();
+  const journal = isObject(raw) && isObject(raw.journal) ? (raw.journal as Record<string, unknown>) : null;
+  for (const entry of asArray(journal?.tracked_behaviors)) {
+    if (!isObject(entry)) continue;
+    const tracker = isObject(entry.behavior_tracker) ? (entry.behavior_tracker as Record<string, unknown>) : null;
+    const id = asNumber(tracker?.id);
+    if (id === null) continue;
+    const magnitude = isObject(tracker?.magnitude) ? (tracker!.magnitude as Record<string, unknown>) : null;
+    specs.set(id, {
+      question_type: asString(tracker?.question_type),
+      magnitude: magnitude
+        ? {
+            type: asString(magnitude.type),
+            units: asString(magnitude.units),
+            minimum: asNumber(magnitude.minimum_inclusive),
+            maximum: asNumber(magnitude.maximum_inclusive),
+          }
+        : null,
+    });
+  }
+  return specs;
+}
+
+export type ExistingInput = { behavior_tracker_id: number; input: Record<string, unknown> };
+
+export function answeredInputsFromDraft(raw: unknown): ExistingInput[] {
+  const kept: ExistingInput[] = [];
+  const journal = isObject(raw) && isObject(raw.journal) ? (raw.journal as Record<string, unknown>) : null;
+  for (const entry of asArray(journal?.tracked_behaviors)) {
+    if (!isObject(entry)) continue;
+    const input = isObject(entry.tracker_input) ? (entry.tracker_input as Record<string, unknown>) : null;
+    const id = asNumber(input?.behavior_tracker_id);
+    if (id === null || input === null) continue;
+    if (asBool(input.answered_yes) === null && asNumber(input.magnitude_input_value) === null) continue;
+    const carried: Record<string, unknown> = { behavior_tracker_id: id };
+    if (asBool(input.answered_yes) !== null) carried.answered_yes = asBool(input.answered_yes);
+    if (asNumber(input.magnitude_input_value) !== null) {
+      carried.magnitude_input_value = asNumber(input.magnitude_input_value);
+      carried.magnitude_input_label = asString(input.magnitude_input_label) ?? String(asNumber(input.magnitude_input_value));
+    }
+    if (asNumber(input.time_input_value) !== null) carried.time_input_value = asNumber(input.time_input_value);
+    kept.push({ behavior_tracker_id: id, input: carried });
+  }
+  return kept;
+}
+
+export function verifyWritten(raw: unknown, sent: Array<Record<string, unknown>>): { verified: boolean; missing: number[] } {
+  const written = new Map<number, Record<string, unknown>>();
+  for (const existing of answeredInputsFromDraft(raw)) written.set(existing.behavior_tracker_id, existing.input);
+  const missing = sent
+    .map((input) => Number(input.behavior_tracker_id))
+    .filter((id) => {
+      const back = written.get(id);
+      if (!back) return true;
+      const intended = sent.find((s) => Number(s.behavior_tracker_id) === id)!;
+      if (intended.answered_yes !== undefined && back.answered_yes !== intended.answered_yes) return true;
+      if (intended.magnitude_input_value !== undefined && back.magnitude_input_value !== intended.magnitude_input_value) return true;
+      return false;
+    });
+  return { verified: missing.length === 0, missing };
+}
+
+function toEpochSeconds(value: string | number): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? Math.round(value) : null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : Math.round(parsed / 1000);
+}
 
 export function registerJournalLog(server: McpServer, client: WhoopClient): void {
   server.tool(
     "whoop_journal_log",
-    "WRITE: save the full journal entry for a date — this REPLACES the whole day's entry, so first call whoop_journal to read what's already logged today and resend those entries together with your additions, or they'll be wiped. Use a behavior_tracker_id or exact behavior title/internal name. Empty replacements require allow_empty_replace:true.",
+    "WRITE: log journal behaviors for a date. A behavior is only visible in the app when it is answered, so YES_NO behaviors default to answered_yes:true. Behaviors that accept a magnitude take magnitude_value (e.g. sauna minutes, alcoholic drinks) and an optional time (ISO datetime or epoch seconds) for 'when did you stop'. Entries already answered on that date are preserved unless replace_day:true. The write is confirmed by reading the day back, not by the status code.",
     {
       date: z.iso.date().optional(),
       behaviors: z.array(z.object({
         behavior_tracker_id: z.number().int().optional(),
         behavior: z.string().optional().describe("Exact behavior title or internal name."),
-        answered_yes: z.boolean().optional(),
+        answered_yes: z.boolean().optional().describe("Defaults to true — an unanswered row is invisible in the app."),
         magnitude_value: z.number().optional(),
         magnitude_label: z.string().optional(),
+        time: z.union([z.string(), z.number()]).optional().describe("ISO datetime or epoch seconds for the behavior's time input."),
       })),
       notes: z.string().optional(),
+      replace_day: z.boolean().default(false).describe("Drop every existing answer for the date instead of preserving the ones you did not mention."),
       allow_empty_replace: z.boolean().default(false),
       confirm: z.boolean().default(false),
     },
-    async ({ date, behaviors, notes, allow_empty_replace, confirm }) => {
+    async ({ date, behaviors, notes, replace_day, allow_empty_replace, confirm }) => {
       const d = date ?? todayIso();
+      const draftPath = `/journal-service/v3/journals/drafts/mobile/${d}`;
       if (behaviors.length === 0 && !allow_empty_replace) {
         return {
           content: [{ type: "text", text: jsonOut({ error: "Refusing to replace a journal with zero behaviors. Set allow_empty_replace:true only when intentional." }) }],
@@ -43,64 +134,91 @@ export function registerJournalLog(server: McpServer, client: WhoopClient): void
       const unknown = resolved.filter((b) => !b.definition).map((b) => b.behavior ?? b.behavior_tracker_id);
       if (unknown.length > 0) {
         return {
-          content: [
-            {
-              type: "text",
-              text: jsonOut({
-                error: "Unknown behavior",
-                unknown,
-                hint: "Use whoop_journal_catalog",
-              }),
-            },
-          ],
+          content: [{ type: "text", text: jsonOut({ error: "Unknown behavior", unknown, hint: "Use whoop_journal_catalog" }) }],
           isError: true,
         };
       }
+
+      const draft = await client.get(draftPath).catch(() => null);
+      const specs = specsFromDraft(draft);
+
       for (const b of resolved) {
-        const definition = b.definition!;
-        if (definition.magnitude === "bare" && (b.answered_yes !== undefined || b.magnitude_value !== undefined)) {
-          return { content: [{ type: "text", text: jsonOut({ error: `${definition.title} does not accept a value.` }) }], isError: true };
+        const spec = specs.get(b.behavior_tracker_id!);
+        const range = spec?.magnitude;
+        if (b.magnitude_value !== undefined && spec && !range) {
+          return { content: [{ type: "text", text: jsonOut({ error: `${b.definition!.title} does not take a magnitude.` }) }], isError: true };
         }
-        if (definition.magnitude === "boolean" && (b.answered_yes === undefined || b.magnitude_value !== undefined)) {
-          return { content: [{ type: "text", text: jsonOut({ error: `${definition.title} requires answered_yes and does not accept magnitude_value.` }) }], isError: true };
+        if (b.magnitude_value !== undefined && range && range.minimum !== null && range.maximum !== null
+            && (b.magnitude_value < range.minimum || b.magnitude_value > range.maximum)) {
+          return {
+            content: [{ type: "text", text: jsonOut({ error: `${b.definition!.title} takes ${range.minimum}-${range.maximum} ${range.units ?? "units"}.`, given: b.magnitude_value }) }],
+            isError: true,
+          };
         }
-        if (definition.magnitude === "magnitude" && (b.magnitude_value === undefined || b.answered_yes !== undefined)) {
-          return { content: [{ type: "text", text: jsonOut({ error: `${definition.title} requires magnitude_value and does not accept answered_yes.` }) }], isError: true };
+        if (b.time !== undefined && toEpochSeconds(b.time) === null) {
+          return { content: [{ type: "text", text: jsonOut({ error: `Unparseable time for ${b.definition!.title}.`, given: b.time }) }], isError: true };
         }
       }
-      const tracker_inputs = resolved.map((b) => {
+
+      const requested = resolved.map((b) => {
+        const spec = specs.get(b.behavior_tracker_id!);
         const input: Record<string, unknown> = { behavior_tracker_id: b.behavior_tracker_id };
+        // Unanswered rows are invisible in the app, so an explicit log means yes
+        // unless the caller says otherwise. Only skipped when the live spec says
+        // the behavior asks no yes/no question.
+        const answers = spec?.question_type ? spec.question_type === "YES_NO" : true;
         if (b.answered_yes !== undefined) input.answered_yes = b.answered_yes;
+        else if (answers) input.answered_yes = true;
         if (b.magnitude_value !== undefined) {
           input.magnitude_input_value = b.magnitude_value;
           input.magnitude_input_label = b.magnitude_label ?? String(b.magnitude_value);
         }
+        if (b.time !== undefined) input.time_input_value = toEpochSeconds(b.time);
         return input;
       });
+
+      const requestedIds = new Set(requested.map((i) => Number(i.behavior_tracker_id)));
+      const preserved = replace_day
+        ? []
+        : answeredInputsFromDraft(draft).filter((e) => !requestedIds.has(e.behavior_tracker_id)).map((e) => e.input);
+      const tracker_inputs = [...preserved, ...requested];
+
       const body: Record<string, unknown> = { tracker_inputs };
       if (notes !== undefined) body.notes = notes;
       const path = `/journal-service/v2/journals/entries/user/date/${d}`;
       if (!confirm) {
-        const sampleTitles = resolved
-          .slice(0, 5)
-          .map((b) => b.definition?.title ?? `#${b.behavior_tracker_id}`);
         return {
-          content: [
-            {
-              type: "text",
-              text: jsonOut(
-                preview("PUT", path, {
-                  date: d,
-                  behaviors_count: behaviors.length,
-                  sample_titles: sampleTitles,
-                }),
-              ),
-            },
-          ],
+          content: [{
+            type: "text",
+            text: jsonOut(preview("PUT", path, {
+              date: d,
+              behaviors_count: behaviors.length,
+              preserved_count: preserved.length,
+              sample_titles: resolved.slice(0, 5).map((b) => b.definition?.title ?? `#${b.behavior_tracker_id}`),
+            })),
+          }],
         };
       }
       await client.put(path, body);
-      const out = JournalLogOut.parse({ logged: true as const, date: d, behaviors_count: behaviors.length });
+
+      // Proof by effect: a 200 does not mean the row is answered. Read the day
+      // back and report what actually landed.
+      const after = await client.get(draftPath).catch(() => null);
+      const { verified, missing } = verifyWritten(after, requested);
+      if (!verified) {
+        return {
+          content: [{
+            type: "text",
+            text: jsonOut({
+              error: "Whoop accepted the write but the journal does not show it. These behaviors are still unanswered server-side.",
+              date: d,
+              unconfirmed_behavior_tracker_ids: missing,
+            }),
+          }],
+          isError: true,
+        };
+      }
+      const out = JournalLogOut.parse({ logged: true as const, date: d, behaviors_count: behaviors.length, preserved_count: preserved.length, verified: true as const });
       return { content: [{ type: "text", text: jsonOut(out) }] };
     },
   );

--- a/tests/tools/journal_log.test.ts
+++ b/tests/tools/journal_log.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WhoopClient } from "../../src/whoop/client.js";
+import { registerJournalLog, specsFromDraft, verifyWritten } from "../../src/tools/v2/journal_log.js";
+
+// Draft shape as the v3 endpoint returns it: the behavior's real question type
+// and magnitude range live here, not in the bundled catalog.
+function draft(inputs: Array<Record<string, unknown>>) {
+  return {
+    journal: {
+      journal_entry_id: 1,
+      notes: null,
+      tracked_behaviors: [
+        {
+          behavior_tracker: {
+            id: 1, title: "Alcohol", question_type: "YES_NO", internal_name: "alcohol",
+            magnitude: { type: "range", units: "Drinks", minimum_inclusive: 1, maximum_inclusive: 20 },
+          },
+          tracker_input: inputs.find((i) => i.behavior_tracker_id === 1)
+            ?? { behavior_tracker_id: 1, answered_yes: null, magnitude_input_value: null, time_input_value: null },
+        },
+        {
+          behavior_tracker: {
+            id: 52, title: "Sauna", question_type: "YES_NO", internal_name: "sauna",
+            magnitude: { type: "range", units: "Minutes", minimum_inclusive: 1, maximum_inclusive: 300 },
+          },
+          tracker_input: inputs.find((i) => i.behavior_tracker_id === 52)
+            ?? { behavior_tracker_id: 52, answered_yes: null, magnitude_input_value: null, time_input_value: null },
+        },
+      ],
+    },
+  };
+}
+
+async function connect(register: (server: McpServer) => void): Promise<Client> {
+  const server = new McpServer({ name: "test-server", version: "1" });
+  register(server);
+  const client = new Client({ name: "test-client", version: "1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+function parse(result: unknown) {
+  return JSON.parse(((result as { content: Array<{ text: string }> }).content)[0]!.text);
+}
+
+describe("whoop_journal_log", () => {
+  it("answers the question so the row is visible in the app", async () => {
+    const put = vi.fn().mockResolvedValue({});
+    const get = vi.fn()
+      .mockResolvedValueOnce(draft([]))
+      .mockResolvedValueOnce(draft([{ behavior_tracker_id: 52, answered_yes: true, magnitude_input_value: 9, time_input_value: 1788711660 }]));
+    const whoop = { put, get } as unknown as WhoopClient;
+    const client = await connect((server) => registerJournalLog(server, whoop));
+
+    const result = await client.callTool({
+      name: "whoop_journal_log",
+      arguments: { date: "2026-09-06", behaviors: [{ behavior: "sauna", magnitude_value: 9, time: 1788711660 }], confirm: true },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(parse(result)).toMatchObject({ logged: true, verified: true });
+    expect(put.mock.calls[0]![1]).toMatchObject({
+      tracker_inputs: [{ behavior_tracker_id: 52, answered_yes: true, magnitude_input_value: 9, magnitude_input_label: "9", time_input_value: 1788711660 }],
+    });
+  });
+
+  it("accepts a magnitude the behavior really takes", async () => {
+    const put = vi.fn().mockResolvedValue({});
+    const get = vi.fn()
+      .mockResolvedValueOnce(draft([]))
+      .mockResolvedValueOnce(draft([{ behavior_tracker_id: 1, answered_yes: true, magnitude_input_value: 2 }]));
+    const whoop = { put, get } as unknown as WhoopClient;
+    const client = await connect((server) => registerJournalLog(server, whoop));
+
+    const result = await client.callTool({
+      name: "whoop_journal_log",
+      arguments: { date: "2026-09-05", behaviors: [{ behavior: "alcohol", magnitude_value: 2 }], confirm: true },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(put).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a magnitude outside the behavior's own range", async () => {
+    const put = vi.fn();
+    const get = vi.fn().mockResolvedValue(draft([]));
+    const whoop = { put, get } as unknown as WhoopClient;
+    const client = await connect((server) => registerJournalLog(server, whoop));
+
+    const result = await client.callTool({
+      name: "whoop_journal_log",
+      arguments: { behaviors: [{ behavior: "sauna", magnitude_value: 900 }], confirm: true },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).error).toContain("1-300 Minutes");
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("carries over answers it was not asked to change", async () => {
+    const put = vi.fn().mockResolvedValue({});
+    const existing = { behavior_tracker_id: 1, answered_yes: true, magnitude_input_value: 2, magnitude_input_label: "2" };
+    const get = vi.fn()
+      .mockResolvedValueOnce(draft([existing]))
+      .mockResolvedValueOnce(draft([existing, { behavior_tracker_id: 52, answered_yes: true }]));
+    const whoop = { put, get } as unknown as WhoopClient;
+    const client = await connect((server) => registerJournalLog(server, whoop));
+
+    const result = await client.callTool({
+      name: "whoop_journal_log",
+      arguments: { behaviors: [{ behavior: "sauna" }], confirm: true },
+    });
+
+    expect(parse(result)).toMatchObject({ preserved_count: 1 });
+    expect(put.mock.calls[0]![1]).toMatchObject({
+      tracker_inputs: [
+        { behavior_tracker_id: 1, answered_yes: true, magnitude_input_value: 2 },
+        { behavior_tracker_id: 52, answered_yes: true },
+      ],
+    });
+  });
+
+  it("fails when Whoop accepts the write but the day comes back unanswered", async () => {
+    const put = vi.fn().mockResolvedValue({});
+    const get = vi.fn()
+      .mockResolvedValueOnce(draft([]))
+      .mockResolvedValueOnce(draft([]));
+    const whoop = { put, get } as unknown as WhoopClient;
+    const client = await connect((server) => registerJournalLog(server, whoop));
+
+    const result = await client.callTool({
+      name: "whoop_journal_log",
+      arguments: { behaviors: [{ behavior: "sauna" }], confirm: true },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parse(result).unconfirmed_behavior_tracker_ids).toEqual([52]);
+  });
+});
+
+describe("draft helpers", () => {
+  it("reads the live question type and magnitude range", () => {
+    const specs = specsFromDraft(draft([]));
+    expect(specs.get(52)).toMatchObject({ question_type: "YES_NO", magnitude: { units: "Minutes", minimum: 1, maximum: 300 } });
+  });
+
+  it("treats an unanswered echo as unwritten", () => {
+    const { verified, missing } = verifyWritten(draft([]), [{ behavior_tracker_id: 52, answered_yes: true }]);
+    expect(verified).toBe(false);
+    expect(missing).toEqual([52]);
+  });
+});

--- a/tests/tools/write_validation.test.ts
+++ b/tests/tools/write_validation.test.ts
@@ -246,13 +246,14 @@ describe("write-tool validation through MCP", () => {
     expect(put).not.toHaveBeenCalled();
   });
 
-  it("validates a journal behavior's required value shape", async () => {
+  it("rejects a journal behavior nobody can resolve", async () => {
     const put = vi.fn();
-    const whoop = { put } as unknown as WhoopClient;
+    const get = vi.fn().mockResolvedValue({});
+    const whoop = { put, get } as unknown as WhoopClient;
     const client = await connect((server) => registerJournalLog(server, whoop));
     const result = await client.callTool({
       name: "whoop_journal_log",
-      arguments: { behaviors: [{ behavior: "alcohol", magnitude_value: 2 }], confirm: true },
+      arguments: { behaviors: [{ behavior: "definitely not a behavior" }], confirm: true },
     });
     expect(result.isError).toBe(true);
     expect(put).not.toHaveBeenCalled();


### PR DESCRIPTION
## The bug

`whoop_journal_log` never sends `answered_yes`. Whoop accepts the write and returns 200, but the row lands with `answered_yes: null` and **the app does not render it**. The tool still reports `logged: true`.

Found the hard way: I logged a sauna for a user, told him it was recorded, and he opened the journal to an empty screen. Nothing in the tool's output distinguished that from success.

The field was blocked by the tool's own validation, which reads `magnitude` from the bundled catalog — where all 308 behaviors are `"bare"`. Whoop disagrees. From `GET /journal-service/v3/journals/drafts/mobile/{date}`:

```
Sauna    question_type YES_NO · magnitude range 1-300 Minutes ("for how long (minutes)?")
                              · time_label "When did you stop?"
Alcohol  question_type YES_NO · magnitude range 1-20 Drinks ("How many alcoholic drinks did you have?")
                              · time_label "When was your last drink?"
```

So the tool rejected values the API accepts (`Sauna does not accept a value`) and accepted a write nobody could see.

A second, quieter problem: the endpoint is a whole-day PUT, and the tool sent only the caller's behaviors. Anything the user had tapped in the app that day was erased. The docstring told the caller to read the day and resend it, which makes silent data loss the default for anyone who missed that line.

## The fix

- **Validate against the live draft**, not the bundled `magnitude` field. Errors quote the behavior's real range and units; a behavior the draft doesn't describe isn't gated at all.
- **Default YES_NO behaviors to `answered_yes: true`.** An explicit log means yes; an unanswered row is invisible.
- **Support `magnitude_value` / `magnitude_label` and a `time` input** (ISO datetime or epoch seconds) for behaviors that take them.
- **Preserve answers already on the date.** `replace_day: true` opts back into full replacement.
- **Confirm by reading the day back.** If Whoop returns 200 but the row is still unanswered, the tool returns an error naming those `behavior_tracker_id`s instead of claiming success.

## Tests

`tests/tools/journal_log.test.ts`, driven through the MCP transport with a fake client — each direction fails without the change:

- answered write carries `answered_yes`, duration and time;
- an in-range magnitude (alcohol, 2 drinks) is accepted where it used to be rejected;
- an out-of-range one is refused, quoting `1-300 Minutes`;
- untouched answers are carried over into the PUT;
- a 200 whose read-back is still unanswered surfaces as an error.

One case in `write_validation.test.ts` asserted the old behavior (alcohol + magnitude rejected) and was retargeted to an unresolvable behavior name, which is a real error.

Full suite green: 29 files, 296 tests. `tsc --noEmit` clean.

Verified against the live API on my own account: sauna logged with 9 minutes and a stop time, alcohol with 2 drinks — both now visible in the Whoop app, confirmed on device.

## Note on the bundled catalog

`src/data/behaviors.ts` still labels every behavior `bare`, and this PR stops depending on that field rather than regenerating it (the generator it names, `src/scripts/build_catalogs.ts`, isn't in the tree). Regenerating it from live `question_type` and `magnitude` data would be a good follow-up — happy to do it if you point me at the generator.